### PR TITLE
feat: add ellipse

### DIFF
--- a/crates/eunoia/src/geometry/primitives/point.rs
+++ b/crates/eunoia/src/geometry/primitives/point.rs
@@ -1,5 +1,6 @@
 //! 2D point representation.
 
+use crate::geometry::shapes::Ellipse;
 use crate::geometry::traits::Distance;
 
 /// A point in 2D Cartesian space.
@@ -64,6 +65,23 @@ impl Point {
         (other.y - self.y).atan2(other.x - self.x)
     }
 
+    /// Computes the angle from the origin to this point.
+    ///
+    /// Returns the angle in radians from the positive x-axis, in the range [-π, π].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use eunoia::geometry::primitives::Point;
+    /// use std::f64::consts::PI;
+    ///
+    /// let p = Point::new(1.0, 1.0);
+    /// assert!((p.angle_from_origin() - PI / 4.0).abs() < 1e-10);
+    /// ```
+    pub fn angle_from_origin(&self) -> f64 {
+        self.y.atan2(self.x)
+    }
+
     pub fn rotate_around(&self, other: &Self, angle: f64) -> Self {
         let (sin_theta, cos_theta) = angle.sin_cos();
         let dx = self.x - other.x;
@@ -113,6 +131,11 @@ impl Point {
             x: -self.x,
             y: -self.y,
         }
+    }
+
+    pub fn to_ellipse_frame(self, e: &Ellipse) -> Self {
+        self.translate(-e.center().x(), -e.center().y())
+            .rotate(-e.rotation())
     }
 
     pub const ORIGIN: Point = Point { x: 0.0, y: 0.0 };

--- a/crates/eunoia/src/geometry/shapes.rs
+++ b/crates/eunoia/src/geometry/shapes.rs
@@ -8,7 +8,9 @@
 //! - Diagram-specific operations: `DiagramShape` (composes all of the above)
 
 pub mod circle;
+pub mod ellipse;
 pub mod rectangle;
 
 pub use circle::Circle;
+pub use ellipse::Ellipse;
 pub use rectangle::Rectangle;

--- a/crates/eunoia/src/geometry/shapes/circle.rs
+++ b/crates/eunoia/src/geometry/shapes/circle.rs
@@ -1,5 +1,7 @@
 //! Circle shape implementation.
 
+use std::f64::consts::PI;
+
 use crate::geometry::diagram::IntersectionPoint;
 use crate::geometry::primitives::point;
 use crate::geometry::primitives::Point;
@@ -38,13 +40,13 @@ pub struct Circle {
 impl Area for Circle {
     /// Computes the area of the circle using the formula A = πr².
     fn area(&self) -> f64 {
-        std::f64::consts::PI * self.radius * self.radius
+        PI * self.radius * self.radius
     }
 }
 
 impl Centroid for Circle {
-    fn centroid(&self) -> (f64, f64) {
-        (self.center.x(), self.center.y())
+    fn centroid(&self) -> Point {
+        self.center
     }
 }
 
@@ -67,7 +69,7 @@ impl Distance for Circle {
 impl Perimeter for Circle {
     /// Compute the perimeter of the circle.
     fn perimeter(&self) -> f64 {
-        2.0 * std::f64::consts::PI * self.radius
+        2.0 * PI * self.radius
     }
 }
 
@@ -123,7 +125,7 @@ impl Closed for Circle {
         if d <= (self.radius - other.radius).abs() {
             // One circle is completely inside the other
             let smaller_radius = self.radius.min(other.radius);
-            return std::f64::consts::PI * smaller_radius * smaller_radius;
+            return PI * smaller_radius * smaller_radius;
         }
 
         let r1 = self.radius;
@@ -544,13 +546,13 @@ mod tests {
     #[test]
     fn test_circle_area() {
         let circle = Circle::new(Point::new(0.0, 0.0), 1.0);
-        assert!(approx_eq(circle.area(), std::f64::consts::PI));
+        assert!(approx_eq(circle.area(), PI));
 
         let circle2 = Circle::new(Point::new(0.0, 0.0), 2.0);
-        assert!(approx_eq(circle2.area(), 4.0 * std::f64::consts::PI));
+        assert!(approx_eq(circle2.area(), 4.0 * PI));
 
         let circle3 = Circle::new(Point::new(5.0, 5.0), 3.0);
-        assert!(approx_eq(circle3.area(), 9.0 * std::f64::consts::PI));
+        assert!(approx_eq(circle3.area(), 9.0 * PI));
     }
 
     #[test]
@@ -641,7 +643,7 @@ mod tests {
     fn test_intersection_area_complete_overlap_same_size() {
         let circle1 = Circle::new(Point::new(0.0, 0.0), 2.0);
         let circle2 = Circle::new(Point::new(0.0, 0.0), 2.0);
-        let expected = std::f64::consts::PI * 4.0;
+        let expected = PI * 4.0;
         assert!(approx_eq(circle1.intersection_area(&circle2), expected));
     }
 
@@ -649,7 +651,7 @@ mod tests {
     fn test_intersection_area_one_inside_other() {
         let large = Circle::new(Point::new(0.0, 0.0), 5.0);
         let small = Circle::new(Point::new(1.0, 0.0), 2.0);
-        let expected = std::f64::consts::PI * 4.0; // Area of smaller circle
+        let expected = PI * 4.0; // Area of smaller circle
         assert!(approx_eq(large.intersection_area(&small), expected));
         assert!(approx_eq(small.intersection_area(&large), expected));
     }
@@ -663,7 +665,7 @@ mod tests {
         // For two unit circles with centers 1 apart, there's a known formula
         // The intersection area should be positive and less than π
         assert!(area > 0.0);
-        assert!(area < std::f64::consts::PI);
+        assert!(area < PI);
     }
 
     #[test]
@@ -683,7 +685,7 @@ mod tests {
 
         // Should be positive and at most the smaller circle's area
         assert!(area > 0.0);
-        assert!(area <= std::f64::consts::PI * 1.0 * 1.0);
+        assert!(area <= PI * 1.0 * 1.0);
     }
 
     #[test]
@@ -714,7 +716,7 @@ mod tests {
     fn test_distance_for_overlap_full_overlap() {
         let r1 = 3.0;
         let r2 = 2.0;
-        let overlap = std::f64::consts::PI * r2 * r2; // Full area of smaller circle
+        let overlap = PI * r2 * r2; // Full area of smaller circle
 
         let distance = distance_for_overlap(r1, r2, overlap, None, None).unwrap();
 
@@ -960,16 +962,12 @@ mod tests {
     fn test_perimeter() {
         let c = Circle::new(Point::new(0.0, 0.0), 1.0);
         let perimeter = c.perimeter();
-        assert!(approx_eq(perimeter, 2.0 * std::f64::consts::PI));
+        assert!(approx_eq(perimeter, 2.0 * PI));
     }
 
     #[test]
     fn test_perimeter_various_radii() {
-        let test_cases = vec![
-            (0.5, std::f64::consts::PI),
-            (2.0, 4.0 * std::f64::consts::PI),
-            (10.0, 20.0 * std::f64::consts::PI),
-        ];
+        let test_cases = vec![(0.5, PI), (2.0, 4.0 * PI), (10.0, 20.0 * PI)];
 
         for (radius, expected) in test_cases {
             let c = Circle::new(Point::new(0.0, 0.0), radius);
@@ -980,7 +978,7 @@ mod tests {
     #[test]
     fn test_sector_area_full_circle() {
         let c = Circle::new(Point::new(0.0, 0.0), 2.0);
-        let full_circle_angle = 2.0 * std::f64::consts::PI;
+        let full_circle_angle = 2.0 * PI;
         let sector = c.sector_area(full_circle_angle);
         assert!(approx_eq(sector, c.area()));
     }
@@ -988,7 +986,7 @@ mod tests {
     #[test]
     fn test_sector_area_half_circle() {
         let c = Circle::new(Point::new(0.0, 0.0), 3.0);
-        let half_circle_angle = std::f64::consts::PI;
+        let half_circle_angle = PI;
         let sector = c.sector_area(half_circle_angle);
         assert!(approx_eq(sector, c.area() / 2.0));
     }
@@ -996,7 +994,7 @@ mod tests {
     #[test]
     fn test_sector_area_quarter_circle() {
         let c = Circle::new(Point::new(0.0, 0.0), 4.0);
-        let quarter_circle_angle = std::f64::consts::PI / 2.0;
+        let quarter_circle_angle = PI / 2.0;
         let sector = c.sector_area(quarter_circle_angle);
         assert!(approx_eq(sector, c.area() / 4.0));
     }
@@ -1011,7 +1009,7 @@ mod tests {
     #[test]
     fn test_segment_area_from_angle_semicircle() {
         let c = Circle::new(Point::new(0.0, 0.0), 2.0);
-        let angle = std::f64::consts::PI;
+        let angle = PI;
         let segment = c.segment_area_from_angle(angle);
         // For a semicircle, segment area equals sector area (half circle)
         assert!(approx_eq(segment, c.area() / 2.0));
@@ -1027,7 +1025,7 @@ mod tests {
     #[test]
     fn test_segment_area_from_angle_small() {
         let c = Circle::new(Point::new(0.0, 0.0), 1.0);
-        let angle = std::f64::consts::PI / 6.0; // 30 degrees
+        let angle = PI / 6.0; // 30 degrees
         let segment = c.segment_area_from_angle(angle);
 
         // Segment should be positive and less than sector area
@@ -1061,7 +1059,7 @@ mod tests {
     #[test]
     fn test_segment_area_from_chord_vs_angle_consistency() {
         let c = Circle::new(Point::new(0.0, 0.0), 3.0);
-        let angle = std::f64::consts::PI / 3.0; // 60 degrees
+        let angle = PI / 3.0; // 60 degrees
 
         // Calculate chord length from angle
         let chord_length = 2.0 * c.radius() * (angle / 2.0).sin();
@@ -1076,7 +1074,7 @@ mod tests {
     #[test]
     fn test_segment_area_relationships() {
         let c = Circle::new(Point::new(0.0, 0.0), 1.0);
-        let angle = std::f64::consts::PI / 4.0; // 45 degrees
+        let angle = PI / 4.0; // 45 degrees
 
         let sector = c.sector_area(angle);
         let segment = c.segment_area_from_angle(angle);

--- a/crates/eunoia/src/geometry/shapes/ellipse.rs
+++ b/crates/eunoia/src/geometry/shapes/ellipse.rs
@@ -1,0 +1,758 @@
+//! Ellipse shape implementation.
+//!
+//! This module provides an ellipse implementation for use in Euler and Venn diagrams.
+//! Ellipses are more flexible than circles and can represent elongated or rotated regions,
+//! making them useful for more accurate area-proportional diagrams.
+//!
+//! # Representation
+//!
+//! An ellipse is defined by:
+//! - **Center point**: The center of the ellipse
+//! - **Semi-major axis** (a): Half the length of the longest diameter
+//! - **Semi-minor axis** (b): Half the length of the shortest diameter  
+//! - **Rotation**: Rotation angle in radians (counterclockwise from x-axis)
+//!
+//! # Area Calculations
+//!
+//! The module provides several specialized area computation methods:
+//!
+//! - **Sector area**: The area swept by a radius from the center through an angle θ
+//! - **Segment area**: The area between the ellipse boundary and a chord connecting two points
+//!
+//! These primitives are essential for computing intersection areas in Euler diagrams.
+//!
+//! # Examples
+//!
+//! ```
+//! use eunoia::geometry::shapes::Ellipse;
+//! use eunoia::geometry::traits::Area;
+//! use eunoia::geometry::primitives::Point;
+//!
+//! // Create an ellipse centered at origin
+//! let ellipse = Ellipse::new(Point::new(0.0, 0.0), 5.0, 3.0, 0.0);
+//!
+//! // Compute total area
+//! let area = ellipse.area();
+//!
+//! // Compute sector area for π/4 radians
+//! let sector = ellipse.sector_area(std::f64::consts::PI / 4.0);
+//! ```
+
+use std::f64::consts::PI;
+
+use crate::geometry::primitives::Point;
+use crate::geometry::shapes::Rectangle;
+use crate::geometry::traits::{Area, BoundingBox, Centroid, Closed, Distance, Perimeter};
+
+/// An ellipse defined by center, semi-major and semi-minor axes, and rotation.
+///
+/// Ellipses are oval-shaped closed curves that generalize circles. They are particularly
+/// useful in Euler diagrams when sets have elongated or directional relationships.
+///
+/// # Representation
+///
+/// The ellipse is represented in standard form with:
+/// - A center point `(h, k)`
+/// - Semi-major axis length `a` (≥ semi-minor axis)
+/// - Semi-minor axis length `b` (> 0)
+/// - Rotation angle `φ` in radians (counterclockwise from the positive x-axis)
+///
+/// The canonical equation in the ellipse's local coordinate system is:
+/// ```text
+/// (x/a)² + (y/b)² = 1
+/// ```
+///
+/// # Examples
+///
+/// ```
+/// use eunoia::geometry::shapes::Ellipse;
+/// use eunoia::geometry::primitives::Point;
+/// use eunoia::geometry::traits::Area;
+///
+/// // Create an ellipse at the origin with no rotation
+/// let ellipse = Ellipse::new(Point::new(0.0, 0.0), 5.0, 3.0, 0.0);
+/// assert!((ellipse.area() - 47.12).abs() < 0.01);
+///
+/// // Create a rotated ellipse
+/// let rotated = Ellipse::new(
+///     Point::new(2.0, 3.0),
+///     4.0,
+///     2.0,
+///     std::f64::consts::PI / 4.0  // 45 degrees
+/// );
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Ellipse {
+    center: Point,
+    semi_major: f64,
+    semi_minor: f64,
+    rotation: f64, // in radians
+}
+
+impl Ellipse {
+    /// Creates a new ellipse with the specified parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `center` - The center point of the ellipse
+    /// * `semi_major` - The semi-major axis length (must be ≥ semi_minor)
+    /// * `semi_minor` - The semi-minor axis length (must be > 0)
+    /// * `rotation` - Rotation angle in radians (counterclockwise from x-axis)
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug builds if:
+    /// - `semi_major < semi_minor`
+    /// - `semi_minor <= 0`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use eunoia::geometry::shapes::Ellipse;
+    /// use eunoia::geometry::primitives::Point;
+    ///
+    /// let ellipse = Ellipse::new(Point::new(1.0, 2.0), 4.0, 3.0, 0.0);
+    /// assert_eq!(ellipse.semi_major(), 4.0);
+    /// assert_eq!(ellipse.semi_minor(), 3.0);
+    /// ```
+    pub fn new(center: Point, semi_major: f64, semi_minor: f64, rotation: f64) -> Self {
+        debug_assert!(
+            semi_major >= semi_minor,
+            "Semi-major axis must be >= semi-minor axis"
+        );
+        debug_assert!(semi_minor > 0.0, "Semi-minor axis must be > 0");
+        Self {
+            center,
+            semi_major,
+            semi_minor,
+            rotation,
+        }
+    }
+
+    /// Returns the center point of the ellipse.
+    pub fn center(&self) -> Point {
+        self.center
+    }
+
+    /// Returns the semi-major axis length.
+    pub fn semi_major(&self) -> f64 {
+        self.semi_major
+    }
+
+    /// Returns the semi-minor axis length.
+    pub fn semi_minor(&self) -> f64 {
+        self.semi_minor
+    }
+
+    /// Returns the rotation angle in radians.
+    pub fn rotation(&self) -> f64 {
+        self.rotation
+    }
+
+    /// Computes the area of an elliptical sector from the center through angle θ.
+    ///
+    /// An elliptical sector is the region bounded by:
+    /// - Two radii from the center to the ellipse boundary
+    /// - The ellipse arc between those radii
+    ///
+    /// This uses the exact formula for elliptical sectors, which accounts for
+    /// the non-uniform curvature of the ellipse (unlike circular sectors where
+    /// area is simply ½r²θ).
+    ///
+    /// # Arguments
+    ///
+    /// * `theta` - The angle in radians from the semi-major axis
+    ///
+    /// # Returns
+    ///
+    /// The area of the sector from 0 to θ
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use eunoia::geometry::shapes::Ellipse;
+    /// use eunoia::geometry::primitives::Point;
+    /// use eunoia::geometry::traits::Area;
+    ///
+    /// let ellipse = Ellipse::new(Point::new(0.0, 0.0), 4.0, 2.0, 0.0);
+    ///
+    /// // Quarter sector (π/2 radians)
+    /// let quarter = ellipse.sector_area(std::f64::consts::PI / 2.0);
+    /// assert!((quarter - ellipse.area() / 4.0).abs() < 1e-10);
+    /// ```
+    pub fn sector_area(&self, theta: f64) -> f64 {
+        let a = self.semi_major;
+        let b = self.semi_minor;
+
+        let num = (b - a) * (2.0 * theta).sin();
+        let den = a + b + (b - a) * (2.0 * theta).cos();
+
+        0.5 * a * b * (theta - num.atan2(den))
+    }
+
+    /// Computes the area of an elliptical sector between two angles.
+    ///
+    /// This is equivalent to `sector_area(theta1) - sector_area(theta0)` but
+    /// handles counter-clockwise angle wrapping automatically.
+    ///
+    /// # Arguments
+    ///
+    /// * `theta0` - Starting angle in radians
+    /// * `theta1` - Ending angle in radians
+    ///
+    /// # Returns
+    ///
+    /// The area of the sector from θ₀ to θ₁ (counter-clockwise)
+    ///
+    /// # Note
+    ///
+    /// If θ₁ < θ₀, the function adds 2π to θ₁ to compute the counter-clockwise
+    /// sector that wraps through angle 0.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use eunoia::geometry::shapes::Ellipse;
+    /// use eunoia::geometry::primitives::Point;
+    ///
+    /// let ellipse = Ellipse::new(Point::new(0.0, 0.0), 3.0, 2.0, 0.0);
+    ///
+    /// // Sector from 45° to 135°
+    /// let sector = ellipse.sector_area_between(
+    ///     std::f64::consts::PI / 4.0,
+    ///     3.0 * std::f64::consts::PI / 4.0
+    /// );
+    /// assert!(sector > 0.0);
+    /// ```
+    pub fn sector_area_between(&self, theta0: f64, theta1: f64) -> f64 {
+        let t0 = theta0;
+        let mut t1 = theta1;
+
+        // Ensure CCW ordering.
+        if t1 < t0 {
+            t1 += 2.0 * PI;
+        }
+
+        self.sector_area(t1) - self.sector_area(t0)
+    }
+
+    /// Computes the area of an ellipse segment between two boundary points.
+    ///
+    /// An ellipse segment is the region bounded by:
+    /// - The ellipse arc between two points on the boundary
+    /// - The chord (straight line) connecting those two points
+    ///
+    /// This method automatically handles:
+    /// - Coordinate system transformation to the ellipse's local frame
+    /// - Counter-clockwise angle ordering
+    /// - Minor arc (≤ 180°) vs major arc (> 180°) selection
+    ///
+    /// # Algorithm
+    ///
+    /// 1. Transform points to ellipse coordinate system (centered, unrotated)
+    /// 2. Compute angles θ₀ and θ₁ for each point
+    /// 3. Ensure counter-clockwise ordering (add 2π if needed)
+    /// 4. Calculate segment as: sector - triangle (for minor arc)
+    ///    or: total_area - complementary_sector + triangle (for major arc)
+    ///
+    /// # Arguments
+    ///
+    /// * `p0` - First boundary point (in world coordinates)
+    /// * `p1` - Second boundary point (in world coordinates)
+    ///
+    /// # Returns
+    ///
+    /// The area of the segment. When the angular span > π, returns the **major arc**
+    /// segment (the larger of the two possible segments).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use eunoia::geometry::shapes::Ellipse;
+    /// use eunoia::geometry::primitives::Point;
+    /// use eunoia::geometry::traits::Area;
+    ///
+    /// let ellipse = Ellipse::new(Point::new(0.0, 0.0), 5.0, 3.0, 0.0);
+    ///
+    /// // Segment between points on opposite sides (semicircle)
+    /// let p0 = Point::new(5.0, 0.0);   // Right end of major axis
+    /// let p1 = Point::new(-5.0, 0.0);  // Left end of major axis
+    /// let segment = ellipse.ellipse_segment(p0, p1);
+    ///
+    /// // Should be approximately half the ellipse area
+    /// assert!((segment - ellipse.area() / 2.0).abs() < 1e-10);
+    /// ```
+    pub fn ellipse_segment(&self, p0: Point, p1: Point) -> f64 {
+        // 1. Move into ellipse coordinate system.
+        let p0 = p0.to_ellipse_frame(self);
+        let p1 = p1.to_ellipse_frame(self);
+
+        // 2. Compute angles
+        let theta0 = p0.angle_from_origin();
+        let mut theta1 = p1.angle_from_origin();
+
+        // 3. Ensure CCW ordering.
+        if theta1 < theta0 {
+            theta1 += 2.0 * PI;
+        }
+
+        // 4. Triangle correction (signed area of parallelogram / 2).
+        let triangle = 0.5 * (p1.x() * p0.y() - p0.x() * p1.y()).abs();
+
+        // 5. Minor or major arc?
+        if (theta1 - theta0) <= PI {
+            self.sector_area(theta1) - self.sector_area(theta0) - triangle
+        } else {
+            self.area() - (self.sector_area(theta0 + 2.0 * PI) - self.sector_area(theta1))
+                + triangle
+        }
+    }
+}
+
+impl Area for Ellipse {
+    /// Computes the total area of the ellipse using the formula A = πab.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use eunoia::geometry::shapes::Ellipse;
+    /// use eunoia::geometry::primitives::Point;
+    /// use eunoia::geometry::traits::Area;
+    ///
+    /// let ellipse = Ellipse::new(Point::new(0.0, 0.0), 5.0, 3.0, 0.0);
+    /// let area = ellipse.area();
+    /// assert!((area - std::f64::consts::PI * 15.0).abs() < 1e-10);
+    /// ```
+    fn area(&self) -> f64 {
+        PI * self.semi_major * self.semi_minor
+    }
+}
+
+impl Perimeter for Ellipse {
+    /// Computes an approximation of the ellipse perimeter.
+    ///
+    /// Uses Ramanujan's second approximation formula, which provides excellent
+    /// accuracy for all ellipses:
+    ///
+    /// ```text
+    /// P ≈ π(a + b)(1 + 3h / (10 + √(4 - 3h)))
+    /// where h = ((a - b) / (a + b))²
+    /// ```
+    ///
+    /// This approximation has a relative error of less than 0.01% for typical cases.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use eunoia::geometry::shapes::Ellipse;
+    /// use eunoia::geometry::primitives::Point;
+    /// use eunoia::geometry::traits::Perimeter;
+    ///
+    /// let ellipse = Ellipse::new(Point::new(0.0, 0.0), 5.0, 3.0, 0.0);
+    /// let perimeter = ellipse.perimeter();
+    /// assert!(perimeter > 0.0);
+    /// ```
+    fn perimeter(&self) -> f64 {
+        // Approximation using Ramanujan's second formula
+        let a = self.semi_major;
+        let b = self.semi_minor;
+        let h = ((a - b).powi(2)) / ((a + b).powi(2));
+        PI * (a + b) * (1.0 + (3.0 * h) / (10.0 + (4.0 - 3.0 * h).sqrt()))
+    }
+}
+
+impl Centroid for Ellipse {
+    /// Returns the centroid of the ellipse, which is its center point.
+    fn centroid(&self) -> Point {
+        self.center
+    }
+}
+
+impl BoundingBox for Ellipse {
+    /// Computes the axis-aligned bounding box that contains the ellipse.
+    ///
+    /// For a rotated ellipse, this computes the smallest axis-aligned rectangle
+    /// that fully contains the ellipse. The calculation accounts for the rotation
+    /// by projecting the ellipse axes onto the coordinate axes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use eunoia::geometry::shapes::Ellipse;
+    /// use eunoia::geometry::primitives::Point;
+    /// use eunoia::geometry::traits::BoundingBox;
+    ///
+    /// let ellipse = Ellipse::new(Point::new(0.0, 0.0), 5.0, 3.0, 0.0);
+    /// let bbox = ellipse.bounding_box();
+    /// // For unrotated ellipse, bbox dimensions equal 2*semi-major and 2*semi-minor
+    /// ```
+    fn bounding_box(&self) -> Rectangle {
+        let cos_theta = self.rotation.cos();
+        let sin_theta = self.rotation.sin();
+
+        let width = 2.0
+            * ((self.semi_major * cos_theta).powi(2) + (self.semi_minor * sin_theta).powi(2))
+                .sqrt();
+        let height = 2.0
+            * ((self.semi_major * sin_theta).powi(2) + (self.semi_minor * cos_theta).powi(2))
+                .sqrt();
+
+        Rectangle::new(self.center, width, height)
+    }
+}
+
+impl Distance for Ellipse {
+    fn distance(&self, _other: &Self) -> f64 {
+        // Placeholder implementation
+        unimplemented!()
+    }
+}
+
+impl Closed for Ellipse {
+    fn contains(&self, _other: &Self) -> bool {
+        // Placeholder implementation
+        unimplemented!()
+    }
+
+    fn contains_point(&self, _point: &Point) -> bool {
+        // Placeholder implementation
+        unimplemented!()
+    }
+
+    fn intersects(&self, _other: &Self) -> bool {
+        // Placeholder implementation
+        unimplemented!()
+    }
+
+    fn intersection_area(&self, _other: &Self) -> f64 {
+        // Placeholder implementation
+        unimplemented!()
+    }
+
+    fn intersection_points(&self, _other: &Self) -> Vec<Point> {
+        // Placeholder implementation
+        unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geometry::shapes::Circle;
+
+    fn approx_eq(a: f64, b: f64) -> bool {
+        (a - b).abs() < 1e-10
+    }
+
+    #[test]
+    fn test_sector_area_between_quarter() {
+        let ellipse = Ellipse::new(Point::new(0.0, 0.0), 5.0, 3.0, 0.0);
+
+        // Quarter sector from 0 to π/2
+        let sector_between = ellipse.sector_area_between(0.0, PI / 2.0);
+        let expected = ellipse.sector_area(PI / 2.0) - ellipse.sector_area(0.0);
+
+        assert!(approx_eq(sector_between, expected));
+        assert!(approx_eq(sector_between, ellipse.area() / 4.0));
+    }
+
+    #[test]
+    fn test_sector_area_between_with_ccw_adjustment() {
+        let ellipse = Ellipse::new(Point::new(0.0, 0.0), 4.0, 2.0, 0.0);
+
+        // When theta1 < theta0, it should add 2π to theta1 for CCW ordering
+        // Going from 3π/4 to π/4 CCW (wrapping around through 0)
+        let theta0 = 3.0 * PI / 4.0;
+        let theta1 = PI / 4.0;
+
+        let sector_between = ellipse.sector_area_between(theta0, theta1);
+
+        // This should be equivalent to going from 3π/4 to (π/4 + 2π)
+        let expected = ellipse.sector_area(theta1 + 2.0 * PI) - ellipse.sector_area(theta0);
+
+        assert!(
+            approx_eq(sector_between, expected),
+            "Expected {}, got {}",
+            expected,
+            sector_between
+        );
+
+        // The sector should be positive and cover most of the ellipse
+        assert!(sector_between > 0.0);
+        assert!(sector_between > ellipse.area() / 2.0);
+    }
+
+    #[test]
+    fn test_sector_area_between_same_angle() {
+        let ellipse = Ellipse::new(Point::new(1.0, 2.0), 3.0, 2.5, 0.3);
+
+        // Same angle should give zero sector area
+        let angle = PI / 3.0;
+        let sector = ellipse.sector_area_between(angle, angle);
+
+        assert!(approx_eq(sector, 0.0));
+    }
+
+    #[test]
+    fn test_sector_area_between_full_rotation() {
+        let ellipse = Ellipse::new(Point::new(0.0, 0.0), 5.0, 3.0, 0.0);
+
+        // Full rotation: from 0 to 2π
+        let sector = ellipse.sector_area_between(0.0, 2.0 * PI);
+
+        assert!(approx_eq(sector, ellipse.area()));
+    }
+
+    #[test]
+    fn test_sector_full_ellipse() {
+        let ellipse = Ellipse::new(Point::new(0.0, 0.0), 3.0, 2.0, 0.0);
+        let full_angle = 2.0 * PI;
+        let sector = ellipse.sector_area(full_angle);
+        assert!(approx_eq(sector, ellipse.area()));
+    }
+
+    #[test]
+    fn test_sector_half_ellipse() {
+        let ellipse = Ellipse::new(Point::new(0.0, 0.0), 4.0, 3.0, 0.0);
+        let half_angle = PI;
+        let sector = ellipse.sector_area(half_angle);
+        assert!(approx_eq(sector, ellipse.area() / 2.0));
+    }
+
+    #[test]
+    fn test_sector_quarter_ellipse() {
+        let ellipse = Ellipse::new(Point::new(0.0, 0.0), 5.0, 3.0, 0.0);
+        let quarter_angle = PI / 2.0;
+        let sector = ellipse.sector_area(quarter_angle);
+        assert!(approx_eq(sector, ellipse.area() / 4.0));
+    }
+
+    #[test]
+    fn test_sector_zero_angle() {
+        let ellipse = Ellipse::new(Point::new(1.0, 1.0), 3.0, 2.0, 0.5);
+        let sector = ellipse.sector_area(0.0);
+        assert!(approx_eq(sector, 0.0));
+    }
+
+    #[test]
+    fn test_sector_circular_ellipse_matches_circle() {
+        // Create a circle-like ellipse (semi_major == semi_minor)
+        let radius = 3.0;
+        let ellipse = Ellipse::new(Point::new(0.0, 0.0), radius, radius, 0.0);
+        let circle = Circle::new(Point::new(0.0, 0.0), radius);
+
+        let angle = PI / 3.0;
+        let ellipse_sector = ellipse.sector_area(angle);
+        let circle_sector = circle.sector_area(angle);
+
+        assert!(approx_eq(ellipse_sector, circle_sector));
+    }
+
+    #[test]
+    fn test_sector_circular_ellipse_multiple_angles() {
+        let radius = 2.0;
+        let ellipse = Ellipse::new(Point::new(0.0, 0.0), radius, radius, 0.0);
+        let circle = Circle::new(Point::new(0.0, 0.0), radius);
+
+        let test_angles = vec![
+            0.0,
+            PI / 6.0,
+            PI / 4.0,
+            PI / 2.0,
+            PI,
+            3.0 * PI / 2.0,
+            2.0 * PI,
+        ];
+
+        for angle in test_angles {
+            let ellipse_sector = ellipse.sector_area(angle);
+            let circle_sector = circle.sector_area(angle);
+            assert!(
+                approx_eq(ellipse_sector, circle_sector),
+                "Mismatch at angle {}: ellipse={}, circle={}",
+                angle,
+                ellipse_sector,
+                circle_sector
+            );
+        }
+    }
+
+    #[test]
+    fn test_ellipse_segment_semicircle() {
+        let radius = 2.0;
+        let ellipse = Ellipse::new(Point::new(0.0, 0.0), radius, radius, 0.0);
+
+        // Points at opposite ends of diameter (along x-axis)
+        let p0 = Point::new(-radius, 0.0);
+        let p1 = Point::new(radius, 0.0);
+
+        let segment = ellipse.ellipse_segment(p0, p1);
+        // Semicircle segment equals half the circle area
+        assert!(approx_eq(segment, ellipse.area() / 2.0));
+    }
+
+    #[test]
+    fn test_ellipse_segment_circular_matches_circle_segment() {
+        let radius = 3.0;
+        let ellipse = Ellipse::new(Point::new(0.0, 0.0), radius, radius, 0.0);
+        let circle = Circle::new(Point::new(0.0, 0.0), radius);
+
+        // Test angle
+        let angle = PI / 4.0;
+
+        // Points on circle boundary
+        let p0 = Point::new(radius, 0.0);
+        let p1 = Point::new(radius * angle.cos(), radius * angle.sin());
+
+        let ellipse_segment = ellipse.ellipse_segment(p0, p1);
+        let circle_segment = circle.segment_area_from_angle(angle);
+
+        assert!(
+            approx_eq(ellipse_segment, circle_segment),
+            "Circular ellipse segment should match circle segment: ellipse={}, circle={}",
+            ellipse_segment,
+            circle_segment
+        );
+    }
+
+    #[test]
+    fn test_ellipse_segment_small_angle() {
+        let ellipse = Ellipse::new(Point::new(0.0, 0.0), 3.0, 2.0, 0.0);
+
+        let angle = PI / 12.0; // 15 degrees
+        let p0 = Point::new(ellipse.semi_major(), 0.0);
+        let p1 = Point::new(
+            ellipse.semi_major() * angle.cos(),
+            ellipse.semi_minor() * angle.sin(),
+        );
+
+        let segment = ellipse.ellipse_segment(p0, p1);
+
+        // Segment should be positive and less than the sector
+        assert!(segment > 0.0);
+        let sector = ellipse.sector_area(angle);
+        assert!(segment < sector);
+    }
+
+    #[test]
+    fn test_ellipse_segment_zero_angle() {
+        let ellipse = Ellipse::new(Point::new(0.0, 0.0), 4.0, 2.5, 0.0);
+
+        // Same point twice should give zero area
+        let p = Point::new(ellipse.semi_major(), 0.0);
+        let segment = ellipse.ellipse_segment(p, p);
+
+        assert!(approx_eq(segment, 0.0));
+    }
+
+    #[test]
+    fn test_ellipse_segment_with_known_values() {
+        // Reference values computed for ellipse with semi_major=5.0, semi_minor=3.0
+        // Total area: 47.12388980384689
+
+        let ellipse = Ellipse::new(Point::new(0.0, 0.0), 5.0, 3.0, 0.0);
+
+        // Quarter ellipse segment (from θ=0 to θ=π/2)
+        let p0 = Point::new(ellipse.semi_major(), 0.0);
+        let p1 = Point::new(0.0, ellipse.semi_minor());
+        let segment_quarter = ellipse.ellipse_segment(p0, p1);
+        let expected_quarter = 4.280972450961723;
+
+        assert!(
+            approx_eq(segment_quarter, expected_quarter),
+            "Quarter segment: expected {}, got {}",
+            expected_quarter,
+            segment_quarter
+        );
+
+        // Half ellipse segment (from θ=0 to θ=π)
+        let p2 = Point::new(-ellipse.semi_major(), 0.0);
+        let segment_half = ellipse.ellipse_segment(p0, p2);
+        let expected_half = 23.561944901923447;
+
+        assert!(
+            approx_eq(segment_half, expected_half),
+            "Half segment: expected {}, got {}",
+            expected_half,
+            segment_half
+        );
+
+        // Half segment should also equal half the ellipse area
+        assert!(approx_eq(segment_half, ellipse.area() / 2.0));
+    }
+
+    #[test]
+    fn test_ellipse_segment_additional_angles() {
+        let ellipse = Ellipse::new(Point::new(0.0, 0.0), 5.0, 3.0, 0.0);
+
+        // 30 degree segment (π/6)
+        let angle = PI / 6.0;
+        let p0 = Point::new(ellipse.semi_major(), 0.0);
+        let p1 = Point::new(
+            ellipse.semi_major() * angle.cos(),
+            ellipse.semi_minor() * angle.sin(),
+        );
+        let segment_30deg = ellipse.ellipse_segment(p0, p1);
+        let expected_30deg = 0.17699081698724095;
+
+        assert!(
+            approx_eq(segment_30deg, expected_30deg),
+            "30° segment: expected {}, got {}",
+            expected_30deg,
+            segment_30deg
+        );
+
+        // 60 degree segment (π/3)
+        let angle = PI / 3.0;
+        let p2 = Point::new(
+            ellipse.semi_major() * angle.cos(),
+            ellipse.semi_minor() * angle.sin(),
+        );
+        let segment_60deg = ellipse.ellipse_segment(p0, p2);
+        let expected_60deg = 1.3587911055911919;
+
+        assert!(
+            approx_eq(segment_60deg, expected_60deg),
+            "60° segment: expected {}, got {}",
+            expected_60deg,
+            segment_60deg
+        );
+
+        // Additional sanity checks
+        assert!(segment_30deg < segment_60deg);
+        assert!(segment_60deg < ellipse.area() / 4.0);
+    }
+
+    #[test]
+    fn test_ellipse_segment_270_degrees() {
+        let ellipse = Ellipse::new(Point::new(0.0, 0.0), 5.0, 3.0, 0.0);
+
+        // 270 degree segment (3π/2)
+        // When theta1 - theta0 > π, the algorithm computes the MAJOR arc segment.
+        // This is the correct behavior: going CCW from 0° to 270° covers 270° of arc,
+        // which is the larger of the two possible segments between these points.
+        let angle = 3.0 * PI / 2.0;
+        let p0 = Point::new(ellipse.semi_major(), 0.0);
+        let p1 = Point::new(
+            ellipse.semi_major() * angle.cos(),
+            ellipse.semi_minor() * angle.sin(),
+        );
+        let segment_270deg = ellipse.ellipse_segment(p0, p1);
+        let expected_270deg = 42.84291735288517;
+
+        assert!(
+            approx_eq(segment_270deg, expected_270deg),
+            "270° segment: expected {}, got {}",
+            expected_270deg,
+            segment_270deg
+        );
+
+        // Verify this is indeed the major arc (> half the ellipse area)
+        assert!(segment_270deg > ellipse.area() / 2.0);
+
+        // The complementary segment (minor arc) would be the small 90° piece
+        let complementary = ellipse.area() - segment_270deg;
+        assert!(complementary > 0.0);
+        assert!(complementary < ellipse.area() / 4.0);
+    }
+}

--- a/crates/eunoia/src/geometry/shapes/rectangle.rs
+++ b/crates/eunoia/src/geometry/shapes/rectangle.rs
@@ -137,8 +137,8 @@ impl BoundingBox for Rectangle {
 
 impl Centroid for Rectangle {
     /// Returns the centroid (center point) of the rectangle.
-    fn centroid(&self) -> (f64, f64) {
-        (self.center.x(), self.center.y())
+    fn centroid(&self) -> Point {
+        self.center
     }
 }
 
@@ -305,9 +305,9 @@ mod tests {
     #[test]
     fn test_rectangle_centroid() {
         let rect = Rectangle::new(Point::new(3.0, 4.0), 2.0, 2.0);
-        let (cx, cy) = rect.centroid();
-        assert!(approx_eq(cx, 3.0));
-        assert!(approx_eq(cy, 4.0));
+        let centroid = rect.centroid();
+        assert!(approx_eq(centroid.x(), 3.0));
+        assert!(approx_eq(centroid.y(), 4.0));
     }
 
     #[test]

--- a/crates/eunoia/src/geometry/traits.rs
+++ b/crates/eunoia/src/geometry/traits.rs
@@ -29,8 +29,8 @@ pub trait Area {
 
 /// Trait for objects that have a definable centroid (center of mass).
 pub trait Centroid {
-    /// Returns the centroid (center point) as (x, y) coordinates.
-    fn centroid(&self) -> (f64, f64);
+    /// Returns the centroid (center point) as a Point.
+    fn centroid(&self) -> Point;
 }
 
 /// Trait for objects that have a measurable perimeter.


### PR DESCRIPTION
This PR adds basic support for ellipses. Many methods are still not implemented, but we can implement them later on. The main functionality that's added here is computing segments and sectors. We will need especially segments for later on when computing the overlaps of many ellipses.