### PR TITLE
chore(release): v0.1.1

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,0 +1,11 @@
+{
+  "manifest-version": 1,
+  "baseline-sha": "9babddaec30f356498def652ea09c6b1aaa8fe3a",
+  "release-targets": [
+    {
+      "path": ".",
+      "version": "0.1.1",
+      "tag": "v0.1.1"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,8 @@
 # Changelog
+
+## [0.1.1](https://github.com/jolars/eunoia/compare/v0.1.0...v0.1.1) (2026-04-25)
+
+### Bug Fixes
+- parallelize initial layout ([`ee79b51`](https://github.com/jolars/eunoia/commit/ee79b510e8d407c7c3679db4c7e5a2bf450b17b5))
+- remove unwanted println output ([`e4638f1`](https://github.com/jolars/eunoia/commit/e4638f1ccb7cfaebd332e03c63ba12852ea910f6))
+- avoid randomness in iterating over hashmaps ([`82c090b`](https://github.com/jolars/eunoia/commit/82c090b69301a8ef50bb7e4eb46c3b58f6df1a5e))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.81"
 authors = ["Johan Larsson"]


### PR DESCRIPTION
## [0.1.1](https://github.com/jolars/eunoia/compare/v0.1.0...v0.1.1) (2026-04-25)

### Bug Fixes
- parallelize initial layout ([`ee79b51`](https://github.com/jolars/eunoia/commit/ee79b510e8d407c7c3679db4c7e5a2bf450b17b5))
- remove unwanted println output ([`e4638f1`](https://github.com/jolars/eunoia/commit/e4638f1ccb7cfaebd332e03c63ba12852ea910f6))
- avoid randomness in iterating over hashmaps ([`82c090b`](https://github.com/jolars/eunoia/commit/82c090b69301a8ef50bb7e4eb46c3b58f6df1a5e))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).