### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "9babddaec30f356498def652ea09c6b1aaa8fe3a",
+  "baseline-sha": "fa1bc147ea7e820fb73ce2d167ccfb0bbf105a61",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.1.1",
-      "tag": "v0.1.1"
+      "version": "0.2.0",
+      "tag": "v0.2.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.2.0](https://github.com/jolars/eunoia/compare/v0.1.1...v0.2.0) (2026-04-27)
+
+### Features
+- pool solvers and expose in API ([`fa1bc14`](https://github.com/jolars/eunoia/commit/fa1bc147ea7e820fb73ce2d167ccfb0bbf105a61))
+
+### Bug Fixes
+- parallelize outer loop ([`7104528`](https://github.com/jolars/eunoia/commit/71045285242470ddc05a2ff534a7349c62fc6695))
+- correctly normalize ellipse rotation ([`99b8787`](https://github.com/jolars/eunoia/commit/99b8787abf38d20e1c9292857d3820e23c7554ce))
+- fix logic in set clustering ([`c877319`](https://github.com/jolars/eunoia/commit/c877319c1ec050a893eb68e0284f11d7e5bd7fd9))
+- fix gradient computation in initial MDS loss ([`5bd8323`](https://github.com/jolars/eunoia/commit/5bd83239e7037d707e9375bf43e46537b8c61525))
 ## [0.1.1](https://github.com/jolars/eunoia/compare/v0.1.0...v0.1.1) (2026-04-25)
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.81"
 authors = ["Johan Larsson"]


### PR DESCRIPTION
## [0.2.0](https://github.com/jolars/eunoia/compare/v0.1.1...v0.2.0) (2026-04-27)

### Features
- pool solvers and expose in API ([`fa1bc14`](https://github.com/jolars/eunoia/commit/fa1bc147ea7e820fb73ce2d167ccfb0bbf105a61))

### Bug Fixes
- parallelize outer loop ([`7104528`](https://github.com/jolars/eunoia/commit/71045285242470ddc05a2ff534a7349c62fc6695))
- correctly normalize ellipse rotation ([`99b8787`](https://github.com/jolars/eunoia/commit/99b8787abf38d20e1c9292857d3820e23c7554ce))
- fix logic in set clustering ([`c877319`](https://github.com/jolars/eunoia/commit/c877319c1ec050a893eb68e0284f11d7e5bd7fd9))
- fix gradient computation in initial MDS loss ([`5bd8323`](https://github.com/jolars/eunoia/commit/5bd83239e7037d707e9375bf43e46537b8c61525))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).