### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "fa1bc147ea7e820fb73ce2d167ccfb0bbf105a61",
+  "baseline-sha": "f1b0c39553fbedb425e918f56720f8437bb0efdd",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.2.0",
-      "tag": "v0.2.0"
+      "version": "0.3.0",
+      "tag": "v0.3.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.0](https://github.com/jolars/eunoia/compare/v0.2.0...v0.3.0) (2026-04-27)
+
+### Features
+- make lbfgs the default optimizer ([`859ee66`](https://github.com/jolars/eunoia/commit/859ee669b7d8e519d530bdfe08f8f9bad0b71af7))
+
+### Bug Fixes
+- fix underflow in cubic solver ([`f1b0c39`](https://github.com/jolars/eunoia/commit/f1b0c39553fbedb425e918f56720f8437bb0efdd))
 ## [0.2.0](https://github.com/jolars/eunoia/compare/v0.1.1...v0.2.0) (2026-04-27)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.81"
 authors = ["Johan Larsson"]


### PR DESCRIPTION
## [0.3.0](https://github.com/jolars/eunoia/compare/v0.2.0...v0.3.0) (2026-04-27)

### Features
- make lbfgs the default optimizer ([`859ee66`](https://github.com/jolars/eunoia/commit/859ee669b7d8e519d530bdfe08f8f9bad0b71af7))

### Bug Fixes
- fix underflow in cubic solver ([`f1b0c39`](https://github.com/jolars/eunoia/commit/f1b0c39553fbedb425e918f56720f8437bb0efdd))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).