### PR TITLE
chore(release): v0.8.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "36856e262efa242ea5454783a34773a91abfb73c",
+  "baseline-sha": "36a4b477190231b1f2960528d3a785ef92d5c41b",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.7.0",
-      "tag": "v0.7.0"
+      "version": "0.8.0",
+      "tag": "v0.8.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.8.0](https://github.com/jolars/eunoia/compare/v0.7.0...v0.8.0) (2026-05-01)
+
+### Breaking changes
+- make inclusive_areas lazy ([`36a4b47`](https://github.com/jolars/eunoia/commit/36a4b477190231b1f2960528d3a785ef92d5c41b))
+- return geometric params for ellipses, add optim-spec one ([`36f3325`](https://github.com/jolars/eunoia/commit/36f3325bf9910f5e9c08564cd5fa0dbcececcf26))
+
+### Features
+- return geometric params for ellipses, add optim-spec one ([`36f3325`](https://github.com/jolars/eunoia/commit/36f3325bf9910f5e9c08564cd5fa0dbcececcf26))
+
+### Performance Improvements
+- make inclusive_areas lazy ([`36a4b47`](https://github.com/jolars/eunoia/commit/36a4b477190231b1f2960528d3a785ef92d5c41b))
+- don't map out all 2^n - 1 areas ([`64a64d1`](https://github.com/jolars/eunoia/commit/64a64d11e2bc944c78e1d504591b34cc683ced11))
 ## [0.7.0](https://github.com/jolars/eunoia/compare/v0.6.0...v0.7.0) (2026-05-01)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.84.1"
 authors = ["Johan Larsson"]


### PR DESCRIPTION
## [0.8.0](https://github.com/jolars/eunoia/compare/v0.7.0...v0.8.0) (2026-05-01)

### Breaking changes
- make inclusive_areas lazy ([`36a4b47`](https://github.com/jolars/eunoia/commit/36a4b477190231b1f2960528d3a785ef92d5c41b))
- return geometric params for ellipses, add optim-spec one ([`36f3325`](https://github.com/jolars/eunoia/commit/36f3325bf9910f5e9c08564cd5fa0dbcececcf26))

### Features
- return geometric params for ellipses, add optim-spec one ([`36f3325`](https://github.com/jolars/eunoia/commit/36f3325bf9910f5e9c08564cd5fa0dbcececcf26))

### Performance Improvements
- make inclusive_areas lazy ([`36a4b47`](https://github.com/jolars/eunoia/commit/36a4b477190231b1f2960528d3a785ef92d5c41b))
- don't map out all 2^n - 1 areas ([`64a64d1`](https://github.com/jolars/eunoia/commit/64a64d11e2bc944c78e1d504591b34cc683ced11))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).