### PR TITLE
chore(release): v0.9.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "36a4b477190231b1f2960528d3a785ef92d5c41b",
+  "baseline-sha": "d0a066c21aa80804a66d9eaabcbf01e526693c3c",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.8.0",
-      "tag": "v0.8.0"
+      "version": "0.9.0",
+      "tag": "v0.9.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.9.0](https://github.com/jolars/eunoia/compare/v0.8.0...v0.9.0) (2026-05-04)
+
+### Features
+- clean up plotting API ([`d0a066c`](https://github.com/jolars/eunoia/commit/d0a066c21aa80804a66d9eaabcbf01e526693c3c))
+- **plotting:** improve and fix plotting API ([`8fd5293`](https://github.com/jolars/eunoia/commit/8fd52930328b52882f547c6fc93dcccb9f0a3d2e))
+
+### Bug Fixes
+- **plotting:** deal with polygons contained and holes ([`b5c78c8`](https://github.com/jolars/eunoia/commit/b5c78c8dc25ddb267a2a6e4fce4a06b477e121c2))
 ## [0.8.0](https://github.com/jolars/eunoia/compare/v0.7.0...v0.8.0) (2026-05-01)
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.84.1"
 authors = ["Johan Larsson"]


### PR DESCRIPTION
## [0.9.0](https://github.com/jolars/eunoia/compare/v0.8.0...v0.9.0) (2026-05-04)

### Features
- clean up plotting API ([`d0a066c`](https://github.com/jolars/eunoia/commit/d0a066c21aa80804a66d9eaabcbf01e526693c3c))
- **plotting:** improve and fix plotting API ([`8fd5293`](https://github.com/jolars/eunoia/commit/8fd52930328b52882f547c6fc93dcccb9f0a3d2e))

### Bug Fixes
- **plotting:** deal with polygons contained and holes ([`b5c78c8`](https://github.com/jolars/eunoia/commit/b5c78c8dc25ddb267a2a6e4fce4a06b477e121c2))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).