### PR TITLE
chore(release): v0.11.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,16 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "55027cd98add36524aa1dfa3e4f7d568c6d55380",
+  "baseline-sha": "f30ed14613eac9b1339eda60d5e9cd9bd1e8eab4",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.10.0",
-      "tag": "v0.10.0"
+      "version": "0.11.0",
+      "tag": "v0.11.0"
+    },
+    {
+      "path": "ts/",
+      "version": "0.11.0",
+      "tag": "eunoia-npm-v0.11.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.11.0](https://github.com/jolars/eunoia/compare/v0.10.0...v0.11.0) (2026-05-06)
+
+### Features
+- introduce `max_sets` option to cap max sets ([`f30ed14`](https://github.com/jolars/eunoia/commit/f30ed14613eac9b1339eda60d5e9cd9bd1e8eab4))
+- add NPM package ([`ad1c3e7`](https://github.com/jolars/eunoia/commit/ad1c3e71cebdd25b310e10dd5dd53bac10d0a15d))
+- implement `from_shapes` and sanitize API ([`6f5dab1`](https://github.com/jolars/eunoia/commit/6f5dab1030d244e53ce351dc332da60b63a17561))
+
+### Performance Improvements
+- add analytical gradients for all smooth losses ([`f973acf`](https://github.com/jolars/eunoia/commit/f973acf5eb6ee08bfc78cac47ceddc6a13fb749d)), closes [#39](https://github.com/jolars/eunoia/issues/39)
 ## [0.10.0](https://github.com/jolars/eunoia/compare/v0.9.0...v0.10.0) (2026-05-04)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.84.1"
 authors = ["Johan Larsson"]

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [0.11.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.10.0...eunoia-npm-v0.11.0) (2026-05-06)
+
+### Features
+- add NPM package ([`ad1c3e7`](https://github.com/jolars/eunoia/commit/ad1c3e71cebdd25b310e10dd5dd53bac10d0a15d))

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jolars/eunoia",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Area-proportional Euler and Venn diagrams",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## [eunoia: 0.11.0](https://github.com/jolars/eunoia/compare/v0.10.0...v0.11.0) (2026-05-06)

### Features
- introduce `max_sets` option to cap max sets ([`f30ed14`](https://github.com/jolars/eunoia/commit/f30ed14613eac9b1339eda60d5e9cd9bd1e8eab4))
- add NPM package ([`ad1c3e7`](https://github.com/jolars/eunoia/commit/ad1c3e71cebdd25b310e10dd5dd53bac10d0a15d))
- implement `from_shapes` and sanitize API ([`6f5dab1`](https://github.com/jolars/eunoia/commit/6f5dab1030d244e53ce351dc332da60b63a17561))

### Performance Improvements
- add analytical gradients for all smooth losses ([`f973acf`](https://github.com/jolars/eunoia/commit/f973acf5eb6ee08bfc78cac47ceddc6a13fb749d)), closes [#39](https://github.com/jolars/eunoia/issues/39)

## [ts/: 0.11.0](https://github.com/jolars/eunoia/compare/v0.10.0...v0.11.0) (2026-05-06)

### Features
- add NPM package ([`ad1c3e7`](https://github.com/jolars/eunoia/commit/ad1c3e71cebdd25b310e10dd5dd53bac10d0a15d))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).