### PR TITLE
chore(release): v0.12.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,16 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "f30ed14613eac9b1339eda60d5e9cd9bd1e8eab4",
+  "baseline-sha": "4857e4d1afe329653df0118c9c8e795d7c989f8d",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.11.0",
-      "tag": "v0.11.0"
+      "version": "0.12.0",
+      "tag": "v0.12.0"
+    },
+    {
+      "path": "ts",
+      "version": "0.12.0",
+      "tag": "eunoia-npm-v0.12.0"
     },
     {
       "path": "ts/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.12.0](https://github.com/jolars/eunoia/compare/v0.11.0...v0.12.0) (2026-05-06)
+
+### Features
+- **web:** add a landig page and unify web layout ([`7ff0559`](https://github.com/jolars/eunoia/commit/7ff0559cecf1ce5152a19a2c23df3af420290e37))
+- support `complement` as a bounding box ([`9503454`](https://github.com/jolars/eunoia/commit/950345418eb3a862cf1bf2c055e67dec8d32d22b))
+- add ellipse-bounding box gradient via forward-diff ([`1d400b0`](https://github.com/jolars/eunoia/commit/1d400b08587809cb58c34d7bf4545f01aeee5f53))
+- support rectangles ([`5e3e1fb`](https://github.com/jolars/eunoia/commit/5e3e1fb99f0d6490bda268dfa30e02d6eeb48061))
+
+### Bug Fixes
+- **web:** enforce stable ordering of sets ([`2d5c749`](https://github.com/jolars/eunoia/commit/2d5c749e4f85b446c2c4cefa1f7f083d1f9d42fc))
+- make ordering deterministic ([`4f4ee48`](https://github.com/jolars/eunoia/commit/4f4ee48a8fd9a6ead54dfa1c30831c8a59e62904))
+- **web:** handle infinite loop in web app ([`8f36ea4`](https://github.com/jolars/eunoia/commit/8f36ea48c3b8139a3cb127fbab550ceb05f18e74))
+
+### Performance Improvements
+- add gradients for squares and rectangles too ([`50a74f3`](https://github.com/jolars/eunoia/commit/50a74f343bc12bb2d7a958f6dae482fbba0c19ca))
+- wire in analytical gradient for complement case ([`402f92e`](https://github.com/jolars/eunoia/commit/402f92e852788b9f58995dd14e76261f219412a7))
 ## [0.11.0](https://github.com/jolars/eunoia/compare/v0.10.0...v0.11.0) (2026-05-06)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.84.1"
 authors = ["Johan Larsson"]

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.12.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.11.0...eunoia-npm-v0.12.0) (2026-05-06)
+
+### Features
+- support `complement` as a bounding box ([`9503454`](https://github.com/jolars/eunoia/commit/950345418eb3a862cf1bf2c055e67dec8d32d22b))
+- support rectangles ([`5e3e1fb`](https://github.com/jolars/eunoia/commit/5e3e1fb99f0d6490bda268dfa30e02d6eeb48061))
+
 ## [0.11.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.10.0...eunoia-npm-v0.11.0) (2026-05-06)
 
 ### Features

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jolars/eunoia",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Area-proportional Euler and Venn diagrams",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## [eunoia: 0.12.0](https://github.com/jolars/eunoia/compare/v0.11.0...v0.12.0) (2026-05-06)

### Features
- **web:** add a landig page and unify web layout ([`7ff0559`](https://github.com/jolars/eunoia/commit/7ff0559cecf1ce5152a19a2c23df3af420290e37))
- support `complement` as a bounding box ([`9503454`](https://github.com/jolars/eunoia/commit/950345418eb3a862cf1bf2c055e67dec8d32d22b))
- add ellipse-bounding box gradient via forward-diff ([`1d400b0`](https://github.com/jolars/eunoia/commit/1d400b08587809cb58c34d7bf4545f01aeee5f53))
- support rectangles ([`5e3e1fb`](https://github.com/jolars/eunoia/commit/5e3e1fb99f0d6490bda268dfa30e02d6eeb48061))

### Bug Fixes
- **web:** enforce stable ordering of sets ([`2d5c749`](https://github.com/jolars/eunoia/commit/2d5c749e4f85b446c2c4cefa1f7f083d1f9d42fc))
- make ordering deterministic ([`4f4ee48`](https://github.com/jolars/eunoia/commit/4f4ee48a8fd9a6ead54dfa1c30831c8a59e62904))
- **web:** handle infinite loop in web app ([`8f36ea4`](https://github.com/jolars/eunoia/commit/8f36ea48c3b8139a3cb127fbab550ceb05f18e74))

### Performance Improvements
- add gradients for squares and rectangles too ([`50a74f3`](https://github.com/jolars/eunoia/commit/50a74f343bc12bb2d7a958f6dae482fbba0c19ca))
- wire in analytical gradient for complement case ([`402f92e`](https://github.com/jolars/eunoia/commit/402f92e852788b9f58995dd14e76261f219412a7))

## [ts: 0.12.0](https://github.com/jolars/eunoia/compare/v0.11.0...v0.12.0) (2026-05-06)

### Features
- support `complement` as a bounding box ([`9503454`](https://github.com/jolars/eunoia/commit/950345418eb3a862cf1bf2c055e67dec8d32d22b))
- support rectangles ([`5e3e1fb`](https://github.com/jolars/eunoia/commit/5e3e1fb99f0d6490bda268dfa30e02d6eeb48061))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).