### PR TITLE
chore(release): v0.13.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,16 +1,16 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "4857e4d1afe329653df0118c9c8e795d7c989f8d",
+  "baseline-sha": "0711a3aa48fd5038f3630f384556c04e8ddc9993",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.12.0",
-      "tag": "v0.12.0"
+      "version": "0.13.0",
+      "tag": "v0.13.0"
     },
     {
       "path": "ts",
-      "version": "0.12.0",
-      "tag": "eunoia-npm-v0.12.0"
+      "version": "0.13.0",
+      "tag": "eunoia-npm-v0.13.0"
     },
     {
       "path": "ts/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.13.0](https://github.com/jolars/eunoia/compare/v0.12.0...v0.13.0) (2026-05-07)
+
+### Features
+- **plotting:** provide plotting details for complement ([`9568246`](https://github.com/jolars/eunoia/commit/9568246e9a86e164448588b40309b2ea9c061867)), closes [#56](https://github.com/jolars/eunoia/issues/56)
+
+### Bug Fixes
+- **web:** surface errors probably ([`b16ef94`](https://github.com/jolars/eunoia/commit/b16ef94800ad9da4f45c33171248a37e9e8cc571))
 ## [0.12.0](https://github.com/jolars/eunoia/compare/v0.11.0...v0.12.0) (2026-05-06)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",
@@ -578,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1261,9 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1274,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1284,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1297,18 +1297,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.84.1"
 authors = ["Johan Larsson"]

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.13.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.12.0...eunoia-npm-v0.13.0) (2026-05-07)
+
+### Features
+- **plotting:** provide plotting details for complement ([`9568246`](https://github.com/jolars/eunoia/commit/9568246e9a86e164448588b40309b2ea9c061867)), closes [#56](https://github.com/jolars/eunoia/issues/56)
 ## [0.12.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.11.0...eunoia-npm-v0.12.0) (2026-05-06)
 
 ### Features

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jolars/eunoia",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Area-proportional Euler and Venn diagrams",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## [eunoia: 0.13.0](https://github.com/jolars/eunoia/compare/v0.12.0...v0.13.0) (2026-05-07)

### Features
- **plotting:** provide plotting details for complement ([`9568246`](https://github.com/jolars/eunoia/commit/9568246e9a86e164448588b40309b2ea9c061867)), closes [#56](https://github.com/jolars/eunoia/issues/56)

### Bug Fixes
- **web:** surface errors probably ([`b16ef94`](https://github.com/jolars/eunoia/commit/b16ef94800ad9da4f45c33171248a37e9e8cc571))

## [ts: 0.13.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.12.0...eunoia-npm-v0.13.0) (2026-05-07)

### Features
- **plotting:** provide plotting details for complement ([`9568246`](https://github.com/jolars/eunoia/commit/9568246e9a86e164448588b40309b2ea9c061867)), closes [#56](https://github.com/jolars/eunoia/issues/56)

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).