### PR TITLE
chore(release): v0.14.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,16 +1,16 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "0711a3aa48fd5038f3630f384556c04e8ddc9993",
+  "baseline-sha": "1ff5953c723863fa54d4bb5515f804c20a333c24",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.13.0",
-      "tag": "v0.13.0"
+      "version": "0.14.0",
+      "tag": "v0.14.0"
     },
     {
       "path": "ts",
-      "version": "0.13.0",
-      "tag": "eunoia-npm-v0.13.0"
+      "version": "0.14.0",
+      "tag": "eunoia-npm-v0.14.0"
     },
     {
       "path": "ts/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.14.0](https://github.com/jolars/eunoia/compare/v0.13.0...v0.14.0) (2026-05-11)
+
+### Breaking changes
+- remove strict placement API ([`33c1bf0`](https://github.com/jolars/eunoia/commit/33c1bf00397e728224a12ebf1d097b1a77cb0d46))
+
+### Features
+- remove strict placement API ([`33c1bf0`](https://github.com/jolars/eunoia/commit/33c1bf00397e728224a12ebf1d097b1a77cb0d46))
+- improve raycasting for label placement ([`b239021`](https://github.com/jolars/eunoia/commit/b2390219bcbc0eb7df7d7f1009bf35b1158610a2))
+- add simple labeling api entrypoit ([`40ef7c7`](https://github.com/jolars/eunoia/commit/40ef7c7c1074522e38f2ec88da0e5afbab7fb10f))
+- implement force-directed labeling strategy ([`988a3cf`](https://github.com/jolars/eunoia/commit/988a3cf95cb1c1a2128613dce5548da1c4e7eab1))
+- add label placement strategies ([`e1a72ff`](https://github.com/jolars/eunoia/commit/e1a72ff1c35ee2bf9178caa075c7a6c39b9efcc8))
+- rename `fit` to `euler` ([`8cd1e16`](https://github.com/jolars/eunoia/commit/8cd1e1663109f96320436dba2094d65d89ec01af))
 ## [0.13.0](https://github.com/jolars/eunoia/compare/v0.12.0...v0.13.0) (2026-05-07)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.84.1"
 authors = ["Johan Larsson"]

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.14.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.13.0...eunoia-npm-v0.14.0) (2026-05-11)
+
+### Breaking changes
+- remove strict placement API ([`33c1bf0`](https://github.com/jolars/eunoia/commit/33c1bf00397e728224a12ebf1d097b1a77cb0d46))
+
+### Features
+- remove strict placement API ([`33c1bf0`](https://github.com/jolars/eunoia/commit/33c1bf00397e728224a12ebf1d097b1a77cb0d46))
+- add simple labeling api entrypoit ([`40ef7c7`](https://github.com/jolars/eunoia/commit/40ef7c7c1074522e38f2ec88da0e5afbab7fb10f))
+- implement force-directed labeling strategy ([`988a3cf`](https://github.com/jolars/eunoia/commit/988a3cf95cb1c1a2128613dce5548da1c4e7eab1))
+- add label placement strategies ([`e1a72ff`](https://github.com/jolars/eunoia/commit/e1a72ff1c35ee2bf9178caa075c7a6c39b9efcc8))
+- rename `fit` to `euler` ([`8cd1e16`](https://github.com/jolars/eunoia/commit/8cd1e1663109f96320436dba2094d65d89ec01af))
 ## [0.13.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.12.0...eunoia-npm-v0.13.0) (2026-05-07)
 
 ### Features

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jolars/eunoia",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Area-proportional Euler and Venn diagrams",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## [eunoia: 0.14.0](https://github.com/jolars/eunoia/compare/v0.13.0...v0.14.0) (2026-05-11)

### Breaking changes
- remove strict placement API ([`33c1bf0`](https://github.com/jolars/eunoia/commit/33c1bf00397e728224a12ebf1d097b1a77cb0d46))

### Features
- remove strict placement API ([`33c1bf0`](https://github.com/jolars/eunoia/commit/33c1bf00397e728224a12ebf1d097b1a77cb0d46))
- improve raycasting for label placement ([`b239021`](https://github.com/jolars/eunoia/commit/b2390219bcbc0eb7df7d7f1009bf35b1158610a2))
- add simple labeling api entrypoit ([`40ef7c7`](https://github.com/jolars/eunoia/commit/40ef7c7c1074522e38f2ec88da0e5afbab7fb10f))
- implement force-directed labeling strategy ([`988a3cf`](https://github.com/jolars/eunoia/commit/988a3cf95cb1c1a2128613dce5548da1c4e7eab1))
- add label placement strategies ([`e1a72ff`](https://github.com/jolars/eunoia/commit/e1a72ff1c35ee2bf9178caa075c7a6c39b9efcc8))
- rename `fit` to `euler` ([`8cd1e16`](https://github.com/jolars/eunoia/commit/8cd1e1663109f96320436dba2094d65d89ec01af))

## [ts: 0.14.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.13.0...eunoia-npm-v0.14.0) (2026-05-11)

### Breaking changes
- remove strict placement API ([`33c1bf0`](https://github.com/jolars/eunoia/commit/33c1bf00397e728224a12ebf1d097b1a77cb0d46))

### Features
- remove strict placement API ([`33c1bf0`](https://github.com/jolars/eunoia/commit/33c1bf00397e728224a12ebf1d097b1a77cb0d46))
- add simple labeling api entrypoit ([`40ef7c7`](https://github.com/jolars/eunoia/commit/40ef7c7c1074522e38f2ec88da0e5afbab7fb10f))
- implement force-directed labeling strategy ([`988a3cf`](https://github.com/jolars/eunoia/commit/988a3cf95cb1c1a2128613dce5548da1c4e7eab1))
- add label placement strategies ([`e1a72ff`](https://github.com/jolars/eunoia/commit/e1a72ff1c35ee2bf9178caa075c7a6c39b9efcc8))
- rename `fit` to `euler` ([`8cd1e16`](https://github.com/jolars/eunoia/commit/8cd1e1663109f96320436dba2094d65d89ec01af))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).