### PR TITLE
chore(release): v0.15.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,16 +1,16 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "1ff5953c723863fa54d4bb5515f804c20a333c24",
+  "baseline-sha": "b9bf06f953a72e58342a3caed305da48bddac763",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.14.0",
-      "tag": "v0.14.0"
+      "version": "0.15.0",
+      "tag": "v0.15.0"
     },
     {
       "path": "ts",
-      "version": "0.14.0",
-      "tag": "eunoia-npm-v0.14.0"
+      "version": "0.15.0",
+      "tag": "eunoia-npm-v0.15.0"
     },
     {
       "path": "ts/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.15.0](https://github.com/jolars/eunoia/compare/v0.14.0...v0.15.0) (2026-05-12)
+
+### Features
+- **plotting:** expose `leader_gap` ([`33704a4`](https://github.com/jolars/eunoia/commit/33704a4787986aea46597235b25b9b126469d59f))
+- **plotting:** expose `leader_end` ([`bcb11ce`](https://github.com/jolars/eunoia/commit/bcb11ce47ad91ef99bf1a0faf2321000968ffb68))
 ## [0.14.0](https://github.com/jolars/eunoia/compare/v0.13.0...v0.14.0) (2026-05-11)
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.84.1"
 authors = ["Johan Larsson"]

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.15.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.14.0...eunoia-npm-v0.15.0) (2026-05-12)
+
+### Features
+- **plotting:** expose `leader_gap` ([`33704a4`](https://github.com/jolars/eunoia/commit/33704a4787986aea46597235b25b9b126469d59f))
+- **plotting:** expose `leader_end` ([`bcb11ce`](https://github.com/jolars/eunoia/commit/bcb11ce47ad91ef99bf1a0faf2321000968ffb68))
 ## [0.14.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.13.0...eunoia-npm-v0.14.0) (2026-05-11)
 
 ### Breaking changes

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jolars/eunoia",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Area-proportional Euler and Venn diagrams",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## [eunoia: 0.15.0](https://github.com/jolars/eunoia/compare/v0.14.0...v0.15.0) (2026-05-12)

### Features
- **plotting:** expose `leader_gap` ([`33704a4`](https://github.com/jolars/eunoia/commit/33704a4787986aea46597235b25b9b126469d59f))
- **plotting:** expose `leader_end` ([`bcb11ce`](https://github.com/jolars/eunoia/commit/bcb11ce47ad91ef99bf1a0faf2321000968ffb68))

## [ts: 0.15.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.14.0...eunoia-npm-v0.15.0) (2026-05-12)

### Features
- **plotting:** expose `leader_gap` ([`33704a4`](https://github.com/jolars/eunoia/commit/33704a4787986aea46597235b25b9b126469d59f))
- **plotting:** expose `leader_end` ([`bcb11ce`](https://github.com/jolars/eunoia/commit/bcb11ce47ad91ef99bf1a0faf2321000968ffb68))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).