### PR TITLE
chore(release): v0.16.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,16 +1,16 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "b9bf06f953a72e58342a3caed305da48bddac763",
+  "baseline-sha": "405695285a2061a89e7e90adeac0e2369da3b047",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.15.0",
-      "tag": "v0.15.0"
+      "version": "0.16.0",
+      "tag": "v0.16.0"
     },
     {
       "path": "ts",
-      "version": "0.15.0",
-      "tag": "eunoia-npm-v0.15.0"
+      "version": "0.16.0",
+      "tag": "eunoia-npm-v0.16.0"
     },
     {
       "path": "ts/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [0.16.0](https://github.com/jolars/eunoia/compare/v0.15.0...v0.16.0) (2026-05-28)
+
+### Breaking changes
+- remove plotting feature (make it non-optionable) ([`4056952`](https://github.com/jolars/eunoia/commit/405695285a2061a89e7e90adeac0e2369da3b047))
+- **fitter:** add box-constrained TRF optimizers, default to CmaEsTrf ([`8eda26d`](https://github.com/jolars/eunoia/commit/8eda26d12d510b6ebbdac6cf320cecf81101a7cf))
+- **plotting:** replace curved leaders with edge-coupled leader strategy ([`848c739`](https://github.com/jolars/eunoia/commit/848c739bfdbba21280f43e9ae5a9b725dbff0a4b))
+- add opt-in `parallel` feauture and jobs parameter ([`a42e8a0`](https://github.com/jolars/eunoia/commit/a42e8a0c24cb2c3d6ca594a32ab8be3c004bd30a))
+- drop argmin + argmin-math, complete the basin migration ([`92c6acf`](https://github.com/jolars/eunoia/commit/92c6acf18f17228562070dbceb2e2cd4f4d9d5d7))
+- raise MSRV to 1.91.1 and adopt edition 2024 ([`2f3d282`](https://github.com/jolars/eunoia/commit/2f3d2822e3e106446befd43860c162f4d40baf13))
+
+### Features
+- remove plotting feature (make it non-optionable) ([`4056952`](https://github.com/jolars/eunoia/commit/405695285a2061a89e7e90adeac0e2369da3b047))
+- **fitter:** add box-constrained TRF optimizers, default to CmaEsTrf ([`8eda26d`](https://github.com/jolars/eunoia/commit/8eda26d12d510b6ebbdac6cf320cecf81101a7cf))
+- **plotting:** add elbow labeling strategy ([`79881eb`](https://github.com/jolars/eunoia/commit/79881ebc1515fb9afae8891143aad69b683bbf82))
+- **plotting:** replace curved leaders with edge-coupled leader strategy ([`848c739`](https://github.com/jolars/eunoia/commit/848c739bfdbba21280f43e9ae5a9b725dbff0a4b))
+- **ts:** add venn interface for canonical venn diagrams ([`4bd1304`](https://github.com/jolars/eunoia/commit/4bd13048fa41f64318fb7d039312bdc217cb7f56))
+- **plotting:** add curved leaders ([`33c160e`](https://github.com/jolars/eunoia/commit/33c160e7ed0f9fc6f016d413e67af9515bf83e30))
+- add opt-in `parallel` feauture and jobs parameter ([`a42e8a0`](https://github.com/jolars/eunoia/commit/a42e8a0c24cb2c3d6ca594a32ab8be3c004bd30a))
+
+### Bug Fixes
+- **plotting:** keep gap-straddling labels clear of neighbouring shapes ([`becae27`](https://github.com/jolars/eunoia/commit/becae277b29c358ec2d3b959eab1b1a31d791eb8))
+- **wasm:** fix wasm build failure ([`d720e2c`](https://github.com/jolars/eunoia/commit/d720e2c3c5b13d784d61df4c82f337a5cdde5b69))
+- **ts:** set esModuleInterop to true ([`0de05d5`](https://github.com/jolars/eunoia/commit/0de05d533c85380612f05b3aaa125fc41cb3009f))
+
+### Performance Improvements
+- **fitter:** parallelize corpus-quality test fits across cores ([`9dc0785`](https://github.com/jolars/eunoia/commit/9dc0785d269c479bcff3a517288f18f32e535819))
+- **fitter:** score LM/TRF residual over sparse mask set ([`0bdaf66`](https://github.com/jolars/eunoia/commit/0bdaf660613e70472cc1799171d383ae190900f1)), issue [#89](https://github.com/jolars/eunoia/issues/89)
 ## [0.15.0](https://github.com/jolars/eunoia/compare/v0.14.0...v0.15.0) (2026-05-12)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "basin"
@@ -134,9 +134,9 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -206,18 +206,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.61"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fa72306bb30daf11bc97773431628e5b4916e97aaa74b7d3f625d4d495da02"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.61"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2071365c5c56eae7d77414029dde2f4f4ba151cf68d5a3261c9a40de428ace93"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e78417baa3b3114dc0e95e7357389a249c4da97c3c2b540700079db6171bfd7"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
@@ -322,9 +322,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "env_filter"
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "basin",
  "criterion",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",
@@ -706,9 +706,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "392c70591e8749fe235ddaf513e6f58b26bce3dcc16524cecc8936f75afa161e"
 dependencies = [
  "jiff-static",
  "log",
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -782,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "nalgebra"
@@ -1034,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -1360,7 +1360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1427,11 +1427,11 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen 0.46.0",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1600,18 +1600,18 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
-name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -1694,18 +1694,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 rust-version = "1.91.1"
 authors = ["Johan Larsson"]

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.16.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.15.0...eunoia-npm-v0.16.0) (2026-05-28)
+
+### Breaking changes
+- **plotting:** replace curved leaders with edge-coupled leader strategy ([`848c739`](https://github.com/jolars/eunoia/commit/848c739bfdbba21280f43e9ae5a9b725dbff0a4b))
+
+### Features
+- **plotting:** add elbow labeling strategy ([`79881eb`](https://github.com/jolars/eunoia/commit/79881ebc1515fb9afae8891143aad69b683bbf82))
+- **plotting:** replace curved leaders with edge-coupled leader strategy ([`848c739`](https://github.com/jolars/eunoia/commit/848c739bfdbba21280f43e9ae5a9b725dbff0a4b))
+- **ts:** add venn interface for canonical venn diagrams ([`4bd1304`](https://github.com/jolars/eunoia/commit/4bd13048fa41f64318fb7d039312bdc217cb7f56))
+- **plotting:** add curved leaders ([`33c160e`](https://github.com/jolars/eunoia/commit/33c160e7ed0f9fc6f016d413e67af9515bf83e30))
+
+### Bug Fixes
+- **ts:** set esModuleInterop to true ([`0de05d5`](https://github.com/jolars/eunoia/commit/0de05d533c85380612f05b3aaa125fc41cb3009f))
 ## [0.15.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.14.0...eunoia-npm-v0.15.0) (2026-05-12)
 
 ### Features

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jolars/eunoia",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Area-proportional Euler and Venn diagrams",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## [eunoia: 0.16.0](https://github.com/jolars/eunoia/compare/v0.15.0...v0.16.0) (2026-05-28)

### Breaking changes
- remove plotting feature (make it non-optionable) ([`4056952`](https://github.com/jolars/eunoia/commit/405695285a2061a89e7e90adeac0e2369da3b047))
- **fitter:** add box-constrained TRF optimizers, default to CmaEsTrf ([`8eda26d`](https://github.com/jolars/eunoia/commit/8eda26d12d510b6ebbdac6cf320cecf81101a7cf))
- **plotting:** replace curved leaders with edge-coupled leader strategy ([`848c739`](https://github.com/jolars/eunoia/commit/848c739bfdbba21280f43e9ae5a9b725dbff0a4b))
- add opt-in `parallel` feauture and jobs parameter ([`a42e8a0`](https://github.com/jolars/eunoia/commit/a42e8a0c24cb2c3d6ca594a32ab8be3c004bd30a))
- drop argmin + argmin-math, complete the basin migration ([`92c6acf`](https://github.com/jolars/eunoia/commit/92c6acf18f17228562070dbceb2e2cd4f4d9d5d7))
- raise MSRV to 1.91.1 and adopt edition 2024 ([`2f3d282`](https://github.com/jolars/eunoia/commit/2f3d2822e3e106446befd43860c162f4d40baf13))

### Features
- remove plotting feature (make it non-optionable) ([`4056952`](https://github.com/jolars/eunoia/commit/405695285a2061a89e7e90adeac0e2369da3b047))
- **fitter:** add box-constrained TRF optimizers, default to CmaEsTrf ([`8eda26d`](https://github.com/jolars/eunoia/commit/8eda26d12d510b6ebbdac6cf320cecf81101a7cf))
- **plotting:** add elbow labeling strategy ([`79881eb`](https://github.com/jolars/eunoia/commit/79881ebc1515fb9afae8891143aad69b683bbf82))
- **plotting:** replace curved leaders with edge-coupled leader strategy ([`848c739`](https://github.com/jolars/eunoia/commit/848c739bfdbba21280f43e9ae5a9b725dbff0a4b))
- **ts:** add venn interface for canonical venn diagrams ([`4bd1304`](https://github.com/jolars/eunoia/commit/4bd13048fa41f64318fb7d039312bdc217cb7f56))
- **plotting:** add curved leaders ([`33c160e`](https://github.com/jolars/eunoia/commit/33c160e7ed0f9fc6f016d413e67af9515bf83e30))
- add opt-in `parallel` feauture and jobs parameter ([`a42e8a0`](https://github.com/jolars/eunoia/commit/a42e8a0c24cb2c3d6ca594a32ab8be3c004bd30a))

### Bug Fixes
- **plotting:** keep gap-straddling labels clear of neighbouring shapes ([`becae27`](https://github.com/jolars/eunoia/commit/becae277b29c358ec2d3b959eab1b1a31d791eb8))
- **wasm:** fix wasm build failure ([`d720e2c`](https://github.com/jolars/eunoia/commit/d720e2c3c5b13d784d61df4c82f337a5cdde5b69))
- **ts:** set esModuleInterop to true ([`0de05d5`](https://github.com/jolars/eunoia/commit/0de05d533c85380612f05b3aaa125fc41cb3009f))

### Performance Improvements
- **fitter:** parallelize corpus-quality test fits across cores ([`9dc0785`](https://github.com/jolars/eunoia/commit/9dc0785d269c479bcff3a517288f18f32e535819))
- **fitter:** score LM/TRF residual over sparse mask set ([`0bdaf66`](https://github.com/jolars/eunoia/commit/0bdaf660613e70472cc1799171d383ae190900f1)), issue [#89](https://github.com/jolars/eunoia/issues/89)

## [ts: 0.16.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.15.0...eunoia-npm-v0.16.0) (2026-05-28)

### Breaking changes
- **plotting:** replace curved leaders with edge-coupled leader strategy ([`848c739`](https://github.com/jolars/eunoia/commit/848c739bfdbba21280f43e9ae5a9b725dbff0a4b))

### Features
- **plotting:** add elbow labeling strategy ([`79881eb`](https://github.com/jolars/eunoia/commit/79881ebc1515fb9afae8891143aad69b683bbf82))
- **plotting:** replace curved leaders with edge-coupled leader strategy ([`848c739`](https://github.com/jolars/eunoia/commit/848c739bfdbba21280f43e9ae5a9b725dbff0a4b))
- **ts:** add venn interface for canonical venn diagrams ([`4bd1304`](https://github.com/jolars/eunoia/commit/4bd13048fa41f64318fb7d039312bdc217cb7f56))
- **plotting:** add curved leaders ([`33c160e`](https://github.com/jolars/eunoia/commit/33c160e7ed0f9fc6f016d413e67af9515bf83e30))

### Bug Fixes
- **ts:** set esModuleInterop to true ([`0de05d5`](https://github.com/jolars/eunoia/commit/0de05d533c85380612f05b3aaa125fc41cb3009f))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).