### PR TITLE
chore(release): v0.16.1

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "405695285a2061a89e7e90adeac0e2369da3b047",
+  "baseline-sha": "171786fe2844c6b16611f6324638bf4849564020",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.16.0",
-      "tag": "v0.16.0"
+      "version": "0.16.1",
+      "tag": "v0.16.1"
     },
     {
       "path": "ts",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.16.1](https://github.com/jolars/eunoia/compare/v0.16.0...v0.16.1) (2026-05-28)
+
+### Bug Fixes
+- **fitter:** perturb initial ellipse rotation per restart ([`171786f`](https://github.com/jolars/eunoia/commit/171786fe2844c6b16611f6324638bf4849564020))
+- **fitter:** race TRF from MDS init inside CmaEsTrf when LM stalls ([`f0b02c3`](https://github.com/jolars/eunoia/commit/f0b02c3d9565f63b6b8d19632ca119469011b441))
 ## [0.16.0](https://github.com/jolars/eunoia/compare/v0.15.0...v0.16.0) (2026-05-28)
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "basin",
  "criterion",
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 rust-version = "1.91.1"
 authors = ["Johan Larsson"]


### PR DESCRIPTION
## [eunoia: 0.16.1](https://github.com/jolars/eunoia/compare/v0.16.0...v0.16.1) (2026-05-28)

### Bug Fixes
- **fitter:** perturb initial ellipse rotation per restart ([`171786f`](https://github.com/jolars/eunoia/commit/171786fe2844c6b16611f6324638bf4849564020))
- **fitter:** race TRF from MDS init inside CmaEsTrf when LM stalls ([`f0b02c3`](https://github.com/jolars/eunoia/commit/f0b02c3d9565f63b6b8d19632ca119469011b441))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).