### PR TITLE
chore(release): v0.17.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "171786fe2844c6b16611f6324638bf4849564020",
+  "baseline-sha": "36e2d41bcf87ced7d63dfda834be4eb552e7d754",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.16.1",
-      "tag": "v0.16.1"
+      "version": "0.17.0",
+      "tag": "v0.17.0"
     },
     {
       "path": "ts",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.17.0](https://github.com/jolars/eunoia/compare/v0.16.1...v0.17.0) (2026-06-01)
+
+### Features
+- upgrade to basin 0.9.0 and drop MSRV to 1.87.0 ([`48e89a5`](https://github.com/jolars/eunoia/commit/48e89a5f27aac2fc63c84e5d3494d44858cb0657))
+
+### Bug Fixes
+- bump MSRV to 1.88.0 ([`36e2d41`](https://github.com/jolars/eunoia/commit/36e2d41bcf87ced7d63dfda834be4eb552e7d754))
 ## [0.16.1](https://github.com/jolars/eunoia/compare/v0.16.0...v0.16.1) (2026-05-28)
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "basin",
  "criterion",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",
@@ -706,9 +706,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392c70591e8749fe235ddaf513e6f58b26bce3dcc16524cecc8936f75afa161e"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "log",
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1313,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simba"
@@ -1372,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"
@@ -1688,18 +1688,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["Johan Larsson"]


### PR DESCRIPTION
## [eunoia: 0.17.0](https://github.com/jolars/eunoia/compare/v0.16.1...v0.17.0) (2026-06-01)

### Features
- upgrade to basin 0.9.0 and drop MSRV to 1.87.0 ([`48e89a5`](https://github.com/jolars/eunoia/commit/48e89a5f27aac2fc63c84e5d3494d44858cb0657))

### Bug Fixes
- bump MSRV to 1.88.0 ([`36e2d41`](https://github.com/jolars/eunoia/commit/36e2d41bcf87ced7d63dfda834be4eb552e7d754))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).