### PR TITLE
chore(release): v0.18.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,16 +1,16 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "36e2d41bcf87ced7d63dfda834be4eb552e7d754",
+  "baseline-sha": "d0fb43b99411fcbd321a083d93f6a6853ad143d1",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.17.0",
-      "tag": "v0.17.0"
+      "version": "0.18.0",
+      "tag": "v0.18.0"
     },
     {
       "path": "ts",
-      "version": "0.16.0",
-      "tag": "eunoia-npm-v0.16.0"
+      "version": "0.18.0",
+      "tag": "eunoia-npm-v0.18.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.18.0](https://github.com/jolars/eunoia/compare/v0.17.0...v0.18.0) (2026-06-03)
+
+### Features
+- **ts:** add headless @jolars/eunoia/svg serializer ([`d0fb43b`](https://github.com/jolars/eunoia/commit/d0fb43b99411fcbd321a083d93f6a6853ad143d1))
+
 ## [0.17.0](https://github.com/jolars/eunoia/compare/v0.16.1...v0.17.0) (2026-06-01)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,9 +129,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "bumpalo"
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "basin",
  "criterion",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",
@@ -766,9 +766,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "matrixmultiply"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["Johan Larsson"]

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.18.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.17.0...eunoia-npm-v0.18.0) (2026-06-03)
+
+### Features
+- **ts:** add headless @jolars/eunoia/svg serializer ([`d0fb43b`](https://github.com/jolars/eunoia/commit/d0fb43b99411fcbd321a083d93f6a6853ad143d1))
+
+### Dependencies
+- updated eunoia to v0.18.0
+
 ## [0.16.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.15.0...eunoia-npm-v0.16.0) (2026-05-28)
 
 ### Breaking changes

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jolars/eunoia",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Area-proportional Euler and Venn diagrams",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## [eunoia: 0.18.0](https://github.com/jolars/eunoia/compare/v0.17.0...v0.18.0) (2026-06-03)

### Features
- **ts:** add headless @jolars/eunoia/svg serializer ([`d0fb43b`](https://github.com/jolars/eunoia/commit/d0fb43b99411fcbd321a083d93f6a6853ad143d1))

## [ts: 0.18.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.17.0...eunoia-npm-v0.18.0) (2026-06-03)

### Features
- **ts:** add headless @jolars/eunoia/svg serializer ([`d0fb43b`](https://github.com/jolars/eunoia/commit/d0fb43b99411fcbd321a083d93f6a6853ad143d1))

### Dependencies
- updated eunoia to v0.18.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).