### PR TITLE
chore(release): v1.0.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,16 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "d0fb43b99411fcbd321a083d93f6a6853ad143d1",
+  "baseline-sha": "7efbfe96446cff09b7181fc0950c8991aaccab1f",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.18.0",
-      "tag": "v0.18.0"
+      "version": "1.0.0",
+      "tag": "v1.0.0"
     },
     {
       "path": "ts",
-      "version": "0.18.0",
-      "tag": "eunoia-npm-v0.18.0"
+      "version": "1.0.0",
+      "tag": "eunoia-npm-v1.0.0"
+    }
+  ],
+  "pending-release-targets": [
+    {
+      "path": ".",
+      "version": "1.0.0",
+      "tag": "v1.0.0"
+    },
+    {
+      "path": "ts",
+      "version": "1.0.0",
+      "tag": "eunoia-npm-v1.0.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.0.0](https://github.com/jolars/eunoia/compare/v0.18.0...v1.0.0) (2026-06-12)
 
 This is the first stable release for Eunoia and it includes a number of
 breaking changes (see below). Eunoia uses semantic versioning, so this 1.0.0
@@ -8,6 +8,30 @@ release indicates that the API is now considered stable and future releases
 will follow the semantic versioning rules for backward compatibility. Unless
 there is a major version bump, all changes will be backward compatible with
 this release.
+
+### Breaking changes
+- **geometry:** unify BoundingBox and bounds implementations ([`b0ef190`](https://github.com/jolars/eunoia/commit/b0ef19004322763c895e3c1c3f4ed1307f469902))
+- make input/config enums #[non_exhaustive] ([`79d7d5f`](https://github.com/jolars/eunoia/commit/79d7d5f7e95157feefe974d9e91c18a36e43888d))
+- **plotting:** non_exhaustive + fluent setters on config structs ([`f3e648e`](https://github.com/jolars/eunoia/commit/f3e648efcdfb538b43c8699055a0be1d9dc8683d))
+- make some output-types `#[non_exhaustive]` ([`4d5f045`](https://github.com/jolars/eunoia/commit/4d5f0453a4bb7a1ec835ec3eec25c4c009fe8027))
+- **api:** seal internal math/geometry plumbing before 1.0 ([`5067e89`](https://github.com/jolars/eunoia/commit/5067e89b2d19cddbb27e296e08537afb34dc8be6))
+- **api:** harden public enums and naming for 1.0 ([`604dad3`](https://github.com/jolars/eunoia/commit/604dad37e480505c1eac2323d3dea929d6a92c18))
+- replace default optimizer and add all variants ([`f0dcf77`](https://github.com/jolars/eunoia/commit/f0dcf77f8617bf4ffd41cd98f5b307d1cc42ff24))
+- **ts:** drop support for raw wasm bindings ([`9022f22`](https://github.com/jolars/eunoia/commit/9022f22835380c667f8df6e72e637fe972d4d6f8))
+
+### Features
+- add WIP julia package and C ABI bindings ([`7e29b0f`](https://github.com/jolars/eunoia/commit/7e29b0ff4e9a4d7cc9abca007ba2dfed9378e409))
+- add `restarts` as option ([`2764dad`](https://github.com/jolars/eunoia/commit/2764dad04015525ac542002dbba4e3cfa459fe99))
+- **geometry:** unify BoundingBox and bounds implementations ([`b0ef190`](https://github.com/jolars/eunoia/commit/b0ef19004322763c895e3c1c3f4ed1307f469902))
+- deprecate `sse`/`rmse` in favor of `sum_squared` etc ([`c930288`](https://github.com/jolars/eunoia/commit/c930288470eaa6b4335efb040e679b2821ac1b47))
+- make input/config enums #[non_exhaustive] ([`79d7d5f`](https://github.com/jolars/eunoia/commit/79d7d5f7e95157feefe974d9e91c18a36e43888d))
+- **plotting:** non_exhaustive + fluent setters on config structs ([`f3e648e`](https://github.com/jolars/eunoia/commit/f3e648efcdfb538b43c8699055a0be1d9dc8683d))
+- make some output-types `#[non_exhaustive]` ([`4d5f045`](https://github.com/jolars/eunoia/commit/4d5f0453a4bb7a1ec835ec3eec25c4c009fe8027))
+- **ts:** thread set_anchor_regions through the wasm/ts path ([`cee98b8`](https://github.com/jolars/eunoia/commit/cee98b86acf3c1ae3e0585afe47d43adf2dd4f4b)), refs [#88](https://github.com/jolars/eunoia/issues/88)
+- **plotting:** expose set_anchor_regions on PlotData ([`8795f04`](https://github.com/jolars/eunoia/commit/8795f04b8876ff944022e2ea6c908b586b023fcb)), closes [#88](https://github.com/jolars/eunoia/issues/88)
+- **fitter:** add internal EscapeSolver knob to benchmark memetic escapes ([`498f1a0`](https://github.com/jolars/eunoia/commit/498f1a0c1e4a9511301c193051f8d9518e977a66))
+- replace default optimizer and add all variants ([`f0dcf77`](https://github.com/jolars/eunoia/commit/f0dcf77f8617bf4ffd41cd98f5b307d1cc42ff24))
+- **ts:** drop support for raw wasm bindings ([`9022f22`](https://github.com/jolars/eunoia/commit/9022f22835380c667f8df6e72e637fe972d4d6f8))
 
 ## [0.18.0](https://github.com/jolars/eunoia/compare/v0.17.0...v0.18.0) (2026-06-03)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,9 +129,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bumpalo"
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "0.18.0"
+version = "1.0.0"
 dependencies = [
  "basin",
  "criterion",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-capi"
-version = "0.18.0"
+version = "1.0.0"
 dependencies = [
  "eunoia",
  "serde",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "0.18.0"
+version = "1.0.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "nalgebra"
@@ -1183,9 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1206,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustix"
@@ -1696,18 +1696,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "0.18.0"
+version = "1.0.0"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["Johan Larsson"]

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.0.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.18.0...eunoia-npm-v1.0.0) (2026-06-12)
+
+### Breaking changes
+- replace default optimizer and add all variants ([`f0dcf77`](https://github.com/jolars/eunoia/commit/f0dcf77f8617bf4ffd41cd98f5b307d1cc42ff24))
+- **ts:** drop support for raw wasm bindings ([`9022f22`](https://github.com/jolars/eunoia/commit/9022f22835380c667f8df6e72e637fe972d4d6f8))
+
+### Features
+- add `restarts` as option ([`2764dad`](https://github.com/jolars/eunoia/commit/2764dad04015525ac542002dbba4e3cfa459fe99))
+- **ts:** thread set_anchor_regions through the wasm/ts path ([`cee98b8`](https://github.com/jolars/eunoia/commit/cee98b86acf3c1ae3e0585afe47d43adf2dd4f4b)), refs [#88](https://github.com/jolars/eunoia/issues/88)
+- replace default optimizer and add all variants ([`f0dcf77`](https://github.com/jolars/eunoia/commit/f0dcf77f8617bf4ffd41cd98f5b307d1cc42ff24))
+- **ts:** drop support for raw wasm bindings ([`9022f22`](https://github.com/jolars/eunoia/commit/9022f22835380c667f8df6e72e637fe972d4d6f8))
+
+### Dependencies
+- updated eunoia to v1.0.0
+
 ## [0.18.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.17.0...eunoia-npm-v0.18.0) (2026-06-03)
 
 ### Features

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jolars/eunoia",
-  "version": "0.18.0",
+  "version": "1.0.0",
   "description": "Area-proportional Euler and Venn diagrams",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## [eunoia: 1.0.0](https://github.com/jolars/eunoia/compare/v0.18.0...v1.0.0) (2026-06-12)

This is the first stable release for Eunoia and it includes a number of
breaking changes (see below). Eunoia uses semantic versioning, so this 1.0.0
release indicates that the API is now considered stable and future releases
will follow the semantic versioning rules for backward compatibility. Unless
there is a major version bump, all changes will be backward compatible with
this release.

### Breaking changes
- **geometry:** unify BoundingBox and bounds implementations ([`b0ef190`](https://github.com/jolars/eunoia/commit/b0ef19004322763c895e3c1c3f4ed1307f469902))
- make input/config enums #[non_exhaustive] ([`79d7d5f`](https://github.com/jolars/eunoia/commit/79d7d5f7e95157feefe974d9e91c18a36e43888d))
- **plotting:** non_exhaustive + fluent setters on config structs ([`f3e648e`](https://github.com/jolars/eunoia/commit/f3e648efcdfb538b43c8699055a0be1d9dc8683d))
- make some output-types `#[non_exhaustive]` ([`4d5f045`](https://github.com/jolars/eunoia/commit/4d5f0453a4bb7a1ec835ec3eec25c4c009fe8027))
- **api:** seal internal math/geometry plumbing before 1.0 ([`5067e89`](https://github.com/jolars/eunoia/commit/5067e89b2d19cddbb27e296e08537afb34dc8be6))
- **api:** harden public enums and naming for 1.0 ([`604dad3`](https://github.com/jolars/eunoia/commit/604dad37e480505c1eac2323d3dea929d6a92c18))
- replace default optimizer and add all variants ([`f0dcf77`](https://github.com/jolars/eunoia/commit/f0dcf77f8617bf4ffd41cd98f5b307d1cc42ff24))
- **ts:** drop support for raw wasm bindings ([`9022f22`](https://github.com/jolars/eunoia/commit/9022f22835380c667f8df6e72e637fe972d4d6f8))

### Features
- add WIP julia package and C ABI bindings ([`7e29b0f`](https://github.com/jolars/eunoia/commit/7e29b0ff4e9a4d7cc9abca007ba2dfed9378e409))
- add `restarts` as option ([`2764dad`](https://github.com/jolars/eunoia/commit/2764dad04015525ac542002dbba4e3cfa459fe99))
- **geometry:** unify BoundingBox and bounds implementations ([`b0ef190`](https://github.com/jolars/eunoia/commit/b0ef19004322763c895e3c1c3f4ed1307f469902))
- deprecate `sse`/`rmse` in favor of `sum_squared` etc ([`c930288`](https://github.com/jolars/eunoia/commit/c930288470eaa6b4335efb040e679b2821ac1b47))
- make input/config enums #[non_exhaustive] ([`79d7d5f`](https://github.com/jolars/eunoia/commit/79d7d5f7e95157feefe974d9e91c18a36e43888d))
- **plotting:** non_exhaustive + fluent setters on config structs ([`f3e648e`](https://github.com/jolars/eunoia/commit/f3e648efcdfb538b43c8699055a0be1d9dc8683d))
- make some output-types `#[non_exhaustive]` ([`4d5f045`](https://github.com/jolars/eunoia/commit/4d5f0453a4bb7a1ec835ec3eec25c4c009fe8027))
- **ts:** thread set_anchor_regions through the wasm/ts path ([`cee98b8`](https://github.com/jolars/eunoia/commit/cee98b86acf3c1ae3e0585afe47d43adf2dd4f4b)), refs [#88](https://github.com/jolars/eunoia/issues/88)
- **plotting:** expose set_anchor_regions on PlotData ([`8795f04`](https://github.com/jolars/eunoia/commit/8795f04b8876ff944022e2ea6c908b586b023fcb)), closes [#88](https://github.com/jolars/eunoia/issues/88)
- **fitter:** add internal EscapeSolver knob to benchmark memetic escapes ([`498f1a0`](https://github.com/jolars/eunoia/commit/498f1a0c1e4a9511301c193051f8d9518e977a66))
- replace default optimizer and add all variants ([`f0dcf77`](https://github.com/jolars/eunoia/commit/f0dcf77f8617bf4ffd41cd98f5b307d1cc42ff24))
- **ts:** drop support for raw wasm bindings ([`9022f22`](https://github.com/jolars/eunoia/commit/9022f22835380c667f8df6e72e637fe972d4d6f8))

## [ts: 1.0.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.18.0...eunoia-npm-v1.0.0) (2026-06-12)

### Breaking changes
- replace default optimizer and add all variants ([`f0dcf77`](https://github.com/jolars/eunoia/commit/f0dcf77f8617bf4ffd41cd98f5b307d1cc42ff24))
- **ts:** drop support for raw wasm bindings ([`9022f22`](https://github.com/jolars/eunoia/commit/9022f22835380c667f8df6e72e637fe972d4d6f8))

### Features
- add `restarts` as option ([`2764dad`](https://github.com/jolars/eunoia/commit/2764dad04015525ac542002dbba4e3cfa459fe99))
- **ts:** thread set_anchor_regions through the wasm/ts path ([`cee98b8`](https://github.com/jolars/eunoia/commit/cee98b86acf3c1ae3e0585afe47d43adf2dd4f4b)), refs [#88](https://github.com/jolars/eunoia/issues/88)
- replace default optimizer and add all variants ([`f0dcf77`](https://github.com/jolars/eunoia/commit/f0dcf77f8617bf4ffd41cd98f5b307d1cc42ff24))
- **ts:** drop support for raw wasm bindings ([`9022f22`](https://github.com/jolars/eunoia/commit/9022f22835380c667f8df6e72e637fe972d4d6f8))

### Dependencies
- updated eunoia to v1.0.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).