### PR TITLE
chore(release): v1.1.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "7efbfe96446cff09b7181fc0950c8991aaccab1f",
+  "baseline-sha": "2682050bb6e1f2625f43852adf6bdec224493ad9",
   "release-targets": [
     {
       "path": ".",
-      "version": "1.0.0",
-      "tag": "v1.0.0"
+      "version": "1.1.0",
+      "tag": "v1.1.0"
     },
     {
       "path": "ts",
-      "version": "1.0.0",
-      "tag": "eunoia-npm-v1.0.0"
+      "version": "1.1.0",
+      "tag": "eunoia-npm-v1.1.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "1.0.0",
-      "tag": "v1.0.0"
+      "version": "1.1.0",
+      "tag": "v1.1.0"
     },
     {
       "path": "ts",
-      "version": "1.0.0",
-      "tag": "eunoia-npm-v1.0.0"
+      "version": "1.1.0",
+      "tag": "eunoia-npm-v1.1.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.1.0](https://github.com/jolars/eunoia/compare/v1.0.0...v1.1.0) (2026-06-12)
+
+### Features
+- **loss:** add LogSumAbsolute and SmoothLogSumAbsolute ([`2682050`](https://github.com/jolars/eunoia/commit/2682050bb6e1f2625f43852adf6bdec224493ad9)), closes [#96](https://github.com/jolars/eunoia/issues/96)
+- **julia:** add Makie plotting extension (Phase 3) ([`1477969`](https://github.com/jolars/eunoia/commit/1477969909882bf49954a34808e1db8a51e56040))
+- **capi:** emit region_error and plot_data; surface in Eunoia.jl ([`f20b420`](https://github.com/jolars/eunoia/commit/f20b420921b4b8f761740384b899d5c667d56832))
+- **julia:** membership input, inclusive reconstruction, venn input forms ([`9757e45`](https://github.com/jolars/eunoia/commit/9757e45f547eccac70ebc9e32a6110522b8dc930))
+- **julia:** typed result model and show for Eunoia.jl ([`dbaa746`](https://github.com/jolars/eunoia/commit/dbaa74615ca1d87fa0a0e26be32c928fcd355205))
+
 ## [1.0.0](https://github.com/jolars/eunoia/compare/v0.18.0...v1.0.0) (2026-06-12)
 
 This is the first stable release for Eunoia and it includes a number of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "basin",
  "criterion",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-capi"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "eunoia",
  "serde",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",
@@ -1429,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["Johan Larsson"]

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.0.0...eunoia-npm-v1.1.0) (2026-06-12)
+
+### Dependencies
+- updated eunoia to v1.1.0
+
 ## [1.0.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v0.18.0...eunoia-npm-v1.0.0) (2026-06-12)
 
 ### Breaking changes

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jolars/eunoia",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Area-proportional Euler and Venn diagrams",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## [eunoia: 1.1.0](https://github.com/jolars/eunoia/compare/v1.0.0...v1.1.0) (2026-06-12)

### Features
- **loss:** add LogSumAbsolute and SmoothLogSumAbsolute ([`2682050`](https://github.com/jolars/eunoia/commit/2682050bb6e1f2625f43852adf6bdec224493ad9)), closes [#96](https://github.com/jolars/eunoia/issues/96)
- **julia:** add Makie plotting extension (Phase 3) ([`1477969`](https://github.com/jolars/eunoia/commit/1477969909882bf49954a34808e1db8a51e56040))
- **capi:** emit region_error and plot_data; surface in Eunoia.jl ([`f20b420`](https://github.com/jolars/eunoia/commit/f20b420921b4b8f761740384b899d5c667d56832))
- **julia:** membership input, inclusive reconstruction, venn input forms ([`9757e45`](https://github.com/jolars/eunoia/commit/9757e45f547eccac70ebc9e32a6110522b8dc930))
- **julia:** typed result model and show for Eunoia.jl ([`dbaa746`](https://github.com/jolars/eunoia/commit/dbaa74615ca1d87fa0a0e26be32c928fcd355205))

## [ts: 1.1.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.0.0...eunoia-npm-v1.1.0) (2026-06-12)

### Dependencies
- updated eunoia to v1.1.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).