### PR TITLE
chore(release): v1.2.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "2682050bb6e1f2625f43852adf6bdec224493ad9",
+  "baseline-sha": "770ad103072052ee87b7462ee93de351c4ad0998",
   "release-targets": [
     {
       "path": ".",
-      "version": "1.1.0",
-      "tag": "v1.1.0"
+      "version": "1.2.0",
+      "tag": "v1.2.0"
     },
     {
       "path": "ts",
-      "version": "1.1.0",
-      "tag": "eunoia-npm-v1.1.0"
+      "version": "1.2.0",
+      "tag": "eunoia-npm-v1.2.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "1.1.0",
-      "tag": "v1.1.0"
+      "version": "1.2.0",
+      "tag": "v1.2.0"
     },
     {
       "path": "ts",
-      "version": "1.1.0",
-      "tag": "eunoia-npm-v1.1.0"
+      "version": "1.2.0",
+      "tag": "eunoia-npm-v1.2.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.0](https://github.com/jolars/eunoia/compare/v1.1.0...v1.2.0) (2026-06-14)
+
+### Features
+- add self-contained browser bundle ([`770ad10`](https://github.com/jolars/eunoia/commit/770ad103072052ee87b7462ee93de351c4ad0998))
+- **capi:** forward fitting knobs; surface as euler kwargs in Eunoia.jl ([`a3329e0`](https://github.com/jolars/eunoia/commit/a3329e0e529802c4c278088fd64e507532f17565))
+
 ## [1.1.0](https://github.com/jolars/eunoia/compare/v1.0.0...v1.1.0) (2026-06-12)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "basin",
  "criterion",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-capi"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "eunoia",
  "serde",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",
@@ -739,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1447,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1460,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1470,9 +1470,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1483,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -1526,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["Johan Larsson"]

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.2.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.1.0...eunoia-npm-v1.2.0) (2026-06-14)
+
+### Features
+- add self-contained browser bundle ([`770ad10`](https://github.com/jolars/eunoia/commit/770ad103072052ee87b7462ee93de351c4ad0998))
+
+### Dependencies
+- updated eunoia to v1.2.0
+
 ## [1.1.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.0.0...eunoia-npm-v1.1.0) (2026-06-12)
 
 ### Dependencies

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jolars/eunoia",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Area-proportional Euler and Venn diagrams",
   "private": true,
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
## [eunoia: 1.2.0](https://github.com/jolars/eunoia/compare/v1.1.0...v1.2.0) (2026-06-14)

### Features
- add self-contained browser bundle ([`770ad10`](https://github.com/jolars/eunoia/commit/770ad103072052ee87b7462ee93de351c4ad0998))
- **capi:** forward fitting knobs; surface as euler kwargs in Eunoia.jl ([`a3329e0`](https://github.com/jolars/eunoia/commit/a3329e0e529802c4c278088fd64e507532f17565))

## [ts: 1.2.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.1.0...eunoia-npm-v1.2.0) (2026-06-14)

### Features
- add self-contained browser bundle ([`770ad10`](https://github.com/jolars/eunoia/commit/770ad103072052ee87b7462ee93de351c4ad0998))

### Dependencies
- updated eunoia to v1.2.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).