### PR TITLE
chore(release): v1.3.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "770ad103072052ee87b7462ee93de351c4ad0998",
+  "baseline-sha": "7771ed8cf7d8f932198028b6a3688a06ff3bd0e1",
   "release-targets": [
     {
       "path": ".",
-      "version": "1.2.0",
-      "tag": "v1.2.0"
+      "version": "1.3.0",
+      "tag": "v1.3.0"
     },
     {
       "path": "ts",
-      "version": "1.2.0",
-      "tag": "eunoia-npm-v1.2.0"
+      "version": "1.3.0",
+      "tag": "eunoia-npm-v1.3.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "1.2.0",
-      "tag": "v1.2.0"
+      "version": "1.3.0",
+      "tag": "v1.3.0"
     },
     {
       "path": "ts",
-      "version": "1.2.0",
-      "tag": "eunoia-npm-v1.2.0"
+      "version": "1.3.0",
+      "tag": "eunoia-npm-v1.3.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.3.0](https://github.com/jolars/eunoia/compare/v1.2.0...v1.3.0) (2026-06-15)
+
+### Features
+- **julia:** surface max_sets as an euler kwarg ([`835968d`](https://github.com/jolars/eunoia/commit/835968d16b169376a4ecb144fc3616894b8d6b48))
+- **capi:** forward max_sets into DiagramSpecBuilder ([`d292a25`](https://github.com/jolars/eunoia/commit/d292a250d64fadc3cf7b4c3cbd8e8f08101dc2ee))
+- **julia:** collision-aware Makie labels with leaders ([`105e08c`](https://github.com/jolars/eunoia/commit/105e08cf8f5f9be4f9bd07c8418be83935e6520b))
+- **capi:** add eunoia_place_labels entry point; surface as Eunoia.place_labels ([`d84fc14`](https://github.com/jolars/eunoia/commit/d84fc142e40d31ca18b960408a483445e792b48e))
+- **capi:** forward plot-tuning knobs; surface as euler kwargs in Eunoia.jl ([`563fd77`](https://github.com/jolars/eunoia/commit/563fd77ea0fc311a99a6a991d4100f2179a421c4))
+
+### Bug Fixes
+- **ci:** repair Julia artifact build (zig naming + pinned-toolchain target) ([`7771ed8`](https://github.com/jolars/eunoia/commit/7771ed8cf7d8f932198028b6a3688a06ff3bd0e1))
+
 ## [1.2.0](https://github.com/jolars/eunoia/compare/v1.1.0...v1.2.0) (2026-06-14)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "basin",
  "criterion",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-capi"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "eunoia",
  "serde",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["Johan Larsson"]

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.3.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.2.0...eunoia-npm-v1.3.0) (2026-06-15)
+
+### Dependencies
+- updated eunoia to v1.3.0
+
 ## [1.2.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.1.0...eunoia-npm-v1.2.0) (2026-06-14)
 
 ### Features

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jolars/eunoia",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Area-proportional Euler and Venn diagrams",
   "private": true,
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
## [eunoia: 1.3.0](https://github.com/jolars/eunoia/compare/v1.2.0...v1.3.0) (2026-06-15)

### Features
- **julia:** surface max_sets as an euler kwarg ([`835968d`](https://github.com/jolars/eunoia/commit/835968d16b169376a4ecb144fc3616894b8d6b48))
- **capi:** forward max_sets into DiagramSpecBuilder ([`d292a25`](https://github.com/jolars/eunoia/commit/d292a250d64fadc3cf7b4c3cbd8e8f08101dc2ee))
- **julia:** collision-aware Makie labels with leaders ([`105e08c`](https://github.com/jolars/eunoia/commit/105e08cf8f5f9be4f9bd07c8418be83935e6520b))
- **capi:** add eunoia_place_labels entry point; surface as Eunoia.place_labels ([`d84fc14`](https://github.com/jolars/eunoia/commit/d84fc142e40d31ca18b960408a483445e792b48e))
- **capi:** forward plot-tuning knobs; surface as euler kwargs in Eunoia.jl ([`563fd77`](https://github.com/jolars/eunoia/commit/563fd77ea0fc311a99a6a991d4100f2179a421c4))

### Bug Fixes
- **ci:** repair Julia artifact build (zig naming + pinned-toolchain target) ([`7771ed8`](https://github.com/jolars/eunoia/commit/7771ed8cf7d8f932198028b6a3688a06ff3bd0e1))

## [ts: 1.3.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.2.0...eunoia-npm-v1.3.0) (2026-06-15)

### Dependencies
- updated eunoia to v1.3.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).