### PR TITLE
chore(release): v1.4.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "7771ed8cf7d8f932198028b6a3688a06ff3bd0e1",
+  "baseline-sha": "2d3de4d8ad11ce2f95003347c0f7aa99c914d85f",
   "release-targets": [
     {
       "path": ".",
-      "version": "1.3.0",
-      "tag": "v1.3.0"
+      "version": "1.4.0",
+      "tag": "v1.4.0"
     },
     {
       "path": "ts",
-      "version": "1.3.0",
-      "tag": "eunoia-npm-v1.3.0"
+      "version": "1.4.0",
+      "tag": "eunoia-npm-v1.4.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "1.3.0",
-      "tag": "v1.3.0"
+      "version": "1.4.0",
+      "tag": "v1.4.0"
     },
     {
       "path": "ts",
-      "version": "1.3.0",
-      "tag": "eunoia-npm-v1.3.0"
+      "version": "1.4.0",
+      "tag": "eunoia-npm-v1.4.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.4.0](https://github.com/jolars/eunoia/compare/v1.3.0...v1.4.0) (2026-06-16)
+
+### Features
+- **plotting:** normalize placement of sets-within-sets ([`2d3de4d`](https://github.com/jolars/eunoia/commit/2d3de4d8ad11ce2f95003347c0f7aa99c914d85f))
+- **plotting:** center plot layout within complement container ([`07e3338`](https://github.com/jolars/eunoia/commit/07e3338eb7215185cb5a1d4828b4b19ac0962229))
+- **capi:** expose set_anchor_regions in plot_data ([`d810d58`](https://github.com/jolars/eunoia/commit/d810d58d51d08098a89c64ead943f3433e70ea75))
+- remove julia bindings from this repo ([`50ad043`](https://github.com/jolars/eunoia/commit/50ad04381592cc31663cafbc751b7dcef25d93e0))
+
 ## [1.3.0](https://github.com/jolars/eunoia/compare/v1.2.0...v1.3.0) (2026-06-15)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "basin",
  "criterion",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-capi"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "eunoia",
  "serde",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",
@@ -1346,9 +1346,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["Johan Larsson"]

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.4.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.3.0...eunoia-npm-v1.4.0) (2026-06-16)
+
+### Dependencies
+- updated eunoia to v1.4.0
+
 ## [1.3.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.2.0...eunoia-npm-v1.3.0) (2026-06-15)
 
 ### Dependencies

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jolars/eunoia",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Area-proportional Euler and Venn diagrams",
   "private": true,
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
## [eunoia: 1.4.0](https://github.com/jolars/eunoia/compare/v1.3.0...v1.4.0) (2026-06-16)

### Features
- **plotting:** normalize placement of sets-within-sets ([`2d3de4d`](https://github.com/jolars/eunoia/commit/2d3de4d8ad11ce2f95003347c0f7aa99c914d85f))
- **plotting:** center plot layout within complement container ([`07e3338`](https://github.com/jolars/eunoia/commit/07e3338eb7215185cb5a1d4828b4b19ac0962229))
- **capi:** expose set_anchor_regions in plot_data ([`d810d58`](https://github.com/jolars/eunoia/commit/d810d58d51d08098a89c64ead943f3433e70ea75))
- remove julia bindings from this repo ([`50ad043`](https://github.com/jolars/eunoia/commit/50ad04381592cc31663cafbc751b7dcef25d93e0))

## [ts: 1.4.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.3.0...eunoia-npm-v1.4.0) (2026-06-16)

### Dependencies
- updated eunoia to v1.4.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).