### PR TITLE
chore(release): v1.6.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "6b7a2c38f921d09557e7f671c7d0b872db60066a",
+  "baseline-sha": "4e139af47ce58f73defaa8062c244b8485c75e0d",
   "release-targets": [
     {
       "path": ".",
-      "version": "1.5.0",
-      "tag": "v1.5.0"
+      "version": "1.6.0",
+      "tag": "v1.6.0"
     },
     {
       "path": "ts",
-      "version": "1.5.0",
-      "tag": "eunoia-npm-v1.5.0"
+      "version": "1.6.0",
+      "tag": "eunoia-npm-v1.6.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "1.5.0",
-      "tag": "v1.5.0"
+      "version": "1.6.0",
+      "tag": "v1.6.0"
     },
     {
       "path": "ts",
-      "version": "1.5.0",
-      "tag": "eunoia-npm-v1.5.0"
+      "version": "1.6.0",
+      "tag": "eunoia-npm-v1.6.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.6.0](https://github.com/jolars/eunoia/compare/v1.5.0...v1.6.0) (2026-06-26)
+
+### Features
+- **fitter:** auto-reduce restarts for small smooth-loss fits ([`1a61437`](https://github.com/jolars/eunoia/commit/1a6143709dd4013bd85db49de2787257c7c38819))
+- **fitter:** wire MADS poll-size floor to tolerance; add lever sweep ([`90636b9`](https://github.com/jolars/eunoia/commit/90636b9d7f083e846b4bb82410906440e9788620))
+- **fitter:** add MADS optimizer + benchmark vs Nelder-Mead ([`04a144b`](https://github.com/jolars/eunoia/commit/04a144bfb0329afd7f3e2ef4043e1754a1e78a47))
+- **venn:** add rotated rectangle shape for 4 set venn diagrams ([`322c1d9`](https://github.com/jolars/eunoia/commit/322c1d9c7cc24ec23464116c35d252c41a4b6912))
+- **web:** add rotated rectangles ([`33b9250`](https://github.com/jolars/eunoia/commit/33b92504cbce2b5c0be25ef524bab9f4388fd30f))
+- **shapes:** add RotatedRectangle shape with derivative-free fitting ([`254adbd`](https://github.com/jolars/eunoia/commit/254adbd84888ecc8e6812782e4a0e7f26f012a6b))
+
 ## [1.5.0](https://github.com/jolars/eunoia/compare/v1.4.0...v1.5.0) (2026-06-20)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -99,9 +99,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "basin"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b113ee0389c1b653337d1dd6717fe2a49c440c324566d1ed957934df0302e610"
+checksum = "3af565654f4ed1371593752a2b900b8d279c9fbd326bedaf7db27d8e2ebcd051"
 dependencies = [
  "nalgebra",
  "nalgebra-sparse",
@@ -126,6 +126,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -169,9 +175,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -322,6 +328,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,9 +367,9 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -339,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -362,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "basin",
  "criterion",
@@ -380,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-capi"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "eunoia",
  "serde",
@@ -389,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",
@@ -614,9 +652,9 @@ checksum = "d73d122b937fca067feb0ad74f62388920272b27c356d4df2d0cfdd59e044cf0"
 
 [[package]]
 name = "i_overlay"
-version = "7.0.1"
+version = "7.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f1ff857e4d2bdcc70776e76ca75b2d6a79a5a58f6c9e1e781146bcfe83d257"
+checksum = "bf284de04038af713dad8b4a88d2bc97f1c8c0a87fc1f43e28e3b965d0136d9e"
 dependencies = [
  "i_float",
  "i_key_sort",
@@ -662,10 +700,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -675,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -686,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -957,6 +996,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,7 +1034,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.13.0",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -992,9 +1053,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1147,7 +1208,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1294,6 +1355,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1370,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1380,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1393,18 +1474,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["Johan Larsson"]

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.6.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.5.0...eunoia-npm-v1.6.0) (2026-06-26)
+
+### Features
+- **shapes:** add RotatedRectangle shape with derivative-free fitting ([`254adbd`](https://github.com/jolars/eunoia/commit/254adbd84888ecc8e6812782e4a0e7f26f012a6b))
+
+### Dependencies
+- updated eunoia to v1.6.0
+
 ## [1.5.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.4.0...eunoia-npm-v1.5.0) (2026-06-20)
 
 ### Dependencies

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jolars/eunoia",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Area-proportional Euler and Venn diagrams",
   "private": true,
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
## [eunoia: 1.6.0](https://github.com/jolars/eunoia/compare/v1.5.0...v1.6.0) (2026-06-26)

### Features
- **fitter:** auto-reduce restarts for small smooth-loss fits ([`1a61437`](https://github.com/jolars/eunoia/commit/1a6143709dd4013bd85db49de2787257c7c38819))
- **fitter:** wire MADS poll-size floor to tolerance; add lever sweep ([`90636b9`](https://github.com/jolars/eunoia/commit/90636b9d7f083e846b4bb82410906440e9788620))
- **fitter:** add MADS optimizer + benchmark vs Nelder-Mead ([`04a144b`](https://github.com/jolars/eunoia/commit/04a144bfb0329afd7f3e2ef4043e1754a1e78a47))
- **venn:** add rotated rectangle shape for 4 set venn diagrams ([`322c1d9`](https://github.com/jolars/eunoia/commit/322c1d9c7cc24ec23464116c35d252c41a4b6912))
- **web:** add rotated rectangles ([`33b9250`](https://github.com/jolars/eunoia/commit/33b92504cbce2b5c0be25ef524bab9f4388fd30f))
- **shapes:** add RotatedRectangle shape with derivative-free fitting ([`254adbd`](https://github.com/jolars/eunoia/commit/254adbd84888ecc8e6812782e4a0e7f26f012a6b))

## [ts: 1.6.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.5.0...eunoia-npm-v1.6.0) (2026-06-26)

### Features
- **shapes:** add RotatedRectangle shape with derivative-free fitting ([`254adbd`](https://github.com/jolars/eunoia/commit/254adbd84888ecc8e6812782e4a0e7f26f012a6b))

### Dependencies
- updated eunoia to v1.6.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).