### PR TITLE
chore(release): v1.7.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "81b8238d9b56ebfeaef8b276651569cf23fc32a6",
+  "baseline-sha": "ea5d62f19377dbf4964eebf585063b24bab24b4f",
   "release-targets": [
     {
       "path": ".",
-      "version": "1.6.0",
-      "tag": "v1.6.0"
+      "version": "1.7.0",
+      "tag": "v1.7.0"
     },
     {
       "path": "ts",
-      "version": "1.6.0",
-      "tag": "eunoia-npm-v1.6.0"
+      "version": "1.7.0",
+      "tag": "eunoia-npm-v1.7.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "1.6.0",
-      "tag": "v1.6.0"
+      "version": "1.7.0",
+      "tag": "v1.7.0"
     },
     {
       "path": "ts",
-      "version": "1.6.0",
-      "tag": "eunoia-npm-v1.6.0"
+      "version": "1.7.0",
+      "tag": "eunoia-npm-v1.7.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.7.0](https://github.com/jolars/eunoia/compare/v1.6.0...v1.7.0) (2026-06-30)
+
+### Features
+- **capi:** expose mads/cmaes optimizers and venn complement ([`496b60c`](https://github.com/jolars/eunoia/commit/496b60c352288ce96872c0d4d2c2a8f024857fa7))
+- **web:** add a legend entry for the complement ([`c56faea`](https://github.com/jolars/eunoia/commit/c56faea5c53b3fb5e631c7992a8f3bd773d5f400))
+
 ## [1.6.0](https://github.com/jolars/eunoia/compare/v1.5.0...v1.6.0) (2026-06-26)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "basin"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af565654f4ed1371593752a2b900b8d279c9fbd326bedaf7db27d8e2ebcd051"
+checksum = "a0dbb8f846441e3d0ef60f7c59034447f94702f3386d76c2ecf6cbdaea7a1b2f"
 dependencies = [
  "nalgebra",
  "nalgebra-sparse",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "basin",
  "criterion",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-capi"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "eunoia",
  "serde",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",
@@ -700,9 +700,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -714,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["Johan Larsson"]

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.7.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.6.0...eunoia-npm-v1.7.0) (2026-06-30)
+
+### Features
+- **web:** add a legend entry for the complement ([`c56faea`](https://github.com/jolars/eunoia/commit/c56faea5c53b3fb5e631c7992a8f3bd773d5f400))
+
+### Dependencies
+- updated eunoia to v1.7.0
+
 ## [1.6.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.5.0...eunoia-npm-v1.6.0) (2026-06-26)
 
 ### Features

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jolars/eunoia",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Area-proportional Euler and Venn diagrams",
   "private": true,
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
## [eunoia: 1.7.0](https://github.com/jolars/eunoia/compare/v1.6.0...v1.7.0) (2026-06-30)

### Features
- **capi:** expose mads/cmaes optimizers and venn complement ([`496b60c`](https://github.com/jolars/eunoia/commit/496b60c352288ce96872c0d4d2c2a8f024857fa7))
- **web:** add a legend entry for the complement ([`c56faea`](https://github.com/jolars/eunoia/commit/c56faea5c53b3fb5e631c7992a8f3bd773d5f400))

## [ts: 1.7.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.6.0...eunoia-npm-v1.7.0) (2026-06-30)

### Features
- **web:** add a legend entry for the complement ([`c56faea`](https://github.com/jolars/eunoia/commit/c56faea5c53b3fb5e631c7992a8f3bd773d5f400))

### Dependencies
- updated eunoia to v1.7.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).