### PR TITLE
chore(release): v1.8.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "ea5d62f19377dbf4964eebf585063b24bab24b4f",
+  "baseline-sha": "e76314b702919d8929deb539f0570d2ec244d7e4",
   "release-targets": [
     {
       "path": ".",
-      "version": "1.7.0",
-      "tag": "v1.7.0"
+      "version": "1.8.0",
+      "tag": "v1.8.0"
     },
     {
       "path": "ts",
-      "version": "1.7.0",
-      "tag": "eunoia-npm-v1.7.0"
+      "version": "1.8.0",
+      "tag": "eunoia-npm-v1.8.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "1.7.0",
-      "tag": "v1.7.0"
+      "version": "1.8.0",
+      "tag": "v1.8.0"
     },
     {
       "path": "ts",
-      "version": "1.7.0",
-      "tag": "eunoia-npm-v1.7.0"
+      "version": "1.8.0",
+      "tag": "eunoia-npm-v1.8.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.8.0](https://github.com/jolars/eunoia/compare/v1.7.0...v1.8.0) (2026-06-30)
+
+### Features
+- **plotting:** add matched exterior label placement ([`e76314b`](https://github.com/jolars/eunoia/commit/e76314b702919d8929deb539f0570d2ec244d7e4))
+
 ## [1.7.0](https://github.com/jolars/eunoia/compare/v1.6.0...v1.7.0) (2026-06-30)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "basin",
  "criterion",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-capi"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "eunoia",
  "serde",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["Johan Larsson"]

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.8.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.7.0...eunoia-npm-v1.8.0) (2026-06-30)
+
+### Features
+- **plotting:** add matched exterior label placement ([`e76314b`](https://github.com/jolars/eunoia/commit/e76314b702919d8929deb539f0570d2ec244d7e4))
+
+### Dependencies
+- updated eunoia to v1.8.0
+
 ## [1.7.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.6.0...eunoia-npm-v1.7.0) (2026-06-30)
 
 ### Features

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jolars/eunoia",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Area-proportional Euler and Venn diagrams",
   "private": true,
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
## [eunoia: 1.8.0](https://github.com/jolars/eunoia/compare/v1.7.0...v1.8.0) (2026-06-30)

### Features
- **plotting:** add matched exterior label placement ([`e76314b`](https://github.com/jolars/eunoia/commit/e76314b702919d8929deb539f0570d2ec244d7e4))

## [ts: 1.8.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.7.0...eunoia-npm-v1.8.0) (2026-06-30)

### Features
- **plotting:** add matched exterior label placement ([`e76314b`](https://github.com/jolars/eunoia/commit/e76314b702919d8929deb539f0570d2ec244d7e4))

### Dependencies
- updated eunoia to v1.8.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).