### PR TITLE
chore(release): v1.9.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "3028d06ee7c2875d20360b3560ac162e394b39fe",
+  "baseline-sha": "2d12be2b4dd63386bf2463343d1cbf0663af25c9",
   "release-targets": [
     {
       "path": ".",
-      "version": "1.8.0",
-      "tag": "v1.8.0"
+      "version": "1.9.0",
+      "tag": "v1.9.0"
     },
     {
       "path": "ts",
-      "version": "1.8.0",
-      "tag": "eunoia-npm-v1.8.0"
+      "version": "1.9.0",
+      "tag": "eunoia-npm-v1.9.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "1.8.0",
-      "tag": "v1.8.0"
+      "version": "1.9.0",
+      "tag": "v1.9.0"
     },
     {
       "path": "ts",
-      "version": "1.8.0",
-      "tag": "eunoia-npm-v1.8.0"
+      "version": "1.9.0",
+      "tag": "eunoia-npm-v1.9.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.9.0](https://github.com/jolars/eunoia/compare/v1.8.0...v1.9.0) (2026-08-21)
+
+### Features
+- **capi:** expose label obstacle boxes ([`2d12be2`](https://github.com/jolars/eunoia/commit/2d12be2b4dd63386bf2463343d1cbf0663af25c9))
+- **plotting:** add exterior set-label placement ([`1f09e0d`](https://github.com/jolars/eunoia/commit/1f09e0d2588e1eb8ceec7666209f67e9aec1dfd2))
+- **plotting:** relax the random glyph scatter ([`5c4c3b3`](https://github.com/jolars/eunoia/commit/5c4c3b323ada75d356b85af085b19b362198ad37))
+- **web:** expose member labels as glyphs ([`5e47729`](https://github.com/jolars/eunoia/commit/5e477298a397a9d21a45b3529ac8512086fbf0e2))
+- pack member text labels as glyph boxes ([`8950e8b`](https://github.com/jolars/eunoia/commit/8950e8b37098d91847c36b5caee9a917f119d408))
+- **plotting:** keep glyphs clear of label boxes ([`eb8c850`](https://github.com/jolars/eunoia/commit/eb8c8502c682bbf609637dd3aba981e1dc6b4e29))
+- add eulerGlyphs-style glyph placement ([`3665c2e`](https://github.com/jolars/eunoia/commit/3665c2ecbd536ec461db418050579708f69a8033))
+
+### Bug Fixes
+- **plotting:** keep glyphs clear of region edges ([`badf54a`](https://github.com/jolars/eunoia/commit/badf54a1d517a012ad7159cded863ddf2a29b9de))
+- **fitter:** skip cluster rotation for axis-aligned shapes ([`9dc14dd`](https://github.com/jolars/eunoia/commit/9dc14ddc4501adba849a4af8e3bd8bd9264d5bd5)), refs [#133](https://github.com/jolars/eunoia/issues/133)
+- **fitter:** bound rectangle size params in optimizer box ([`9e4c901`](https://github.com/jolars/eunoia/commit/9e4c9015b3e541dd54117071761179a45bf75360)), refs [#133](https://github.com/jolars/eunoia/issues/133)
+
 ## [1.8.0](https://github.com/jolars/eunoia/compare/v1.7.0...v1.8.0) (2026-07-15)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -135,9 +135,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bumpalo"
@@ -147,9 +147,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.1"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "cast"
@@ -159,9 +159,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -213,18 +213,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "env_filter"
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "basin",
  "criterion",
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-capi"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "eunoia",
  "serde",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "eunoia-wasm"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "console_error_panic_hook",
  "eunoia",
@@ -439,15 +439,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "finitediff"
@@ -467,21 +467,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -636,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "i_float"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c128b7edf06aa28e02763854c84ce5dd91d31ae3e533e24e9b5201a8bc4cd4"
+checksum = "c614c2cfc06cfe8809ccc48cd445864502478e673721ca2a05931fc057ec33a0"
 dependencies = [
  "libm",
 ]
@@ -651,9 +651,9 @@ checksum = "7c6c58d0c60705e66264ce0f788a69a2f21472aeb8188559e7c8c619dbdc10fa"
 
 [[package]]
 name = "i_overlay"
-version = "8.0.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391901c4c5db3968bd11af0d0166c575a6c2f554f3b40d1bfe12df043c3607ca"
+checksum = "ca5d3f41731d03eafa48213609113563099a479f593cc7c635b7e836fc52a3c8"
 dependencies = [
  "i_float",
  "i_key_sort",
@@ -699,11 +699,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.32"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
+ "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -712,11 +713,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.32"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -735,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -863,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -971,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -995,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1010,7 +1021,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.5",
  "rand_chacha 0.9.0",
@@ -1029,9 +1040,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1151,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1163,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1184,7 +1195,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1343,22 +1354,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1552,18 +1563,18 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/eunoia"]
 
 [workspace.package]
 readme = "README.md"
-version = "1.8.0"
+version = "1.9.0"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["Johan Larsson"]

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.9.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.8.0...eunoia-npm-v1.9.0) (2026-08-21)
+
+### Features
+- **plotting:** add exterior set-label placement ([`1f09e0d`](https://github.com/jolars/eunoia/commit/1f09e0d2588e1eb8ceec7666209f67e9aec1dfd2))
+- **web:** add quantities and glyphs to app ([`b1d8aad`](https://github.com/jolars/eunoia/commit/b1d8aad9d9027e1d9505ee4e0c802f8610ac16bb))
+- **ts:** render member-label glyph boxes in toSvg ([`0a29be2`](https://github.com/jolars/eunoia/commit/0a29be20e856c409ec3c00a23a5f77f6f3b53ff4))
+- **ts:** add placeGlyphBoxesForRegions ([`64c92d0`](https://github.com/jolars/eunoia/commit/64c92d027b16502cae1bbfe5ddc30fee222f4ddf))
+- **ts:** color glyphs from their region and give them edges ([`f41b85d`](https://github.com/jolars/eunoia/commit/f41b85dc272cbc698bf3697bcb940107d0b7e1f2))
+- **plotting:** keep glyphs clear of label boxes ([`eb8c850`](https://github.com/jolars/eunoia/commit/eb8c8502c682bbf609637dd3aba981e1dc6b4e29))
+- add eulerGlyphs-style glyph placement ([`3665c2e`](https://github.com/jolars/eunoia/commit/3665c2ecbd536ec461db418050579708f69a8033))
+
+### Bug Fixes
+- **plotting:** keep glyphs clear of region edges ([`badf54a`](https://github.com/jolars/eunoia/commit/badf54a1d517a012ad7159cded863ddf2a29b9de))
+
+### Dependencies
+- updated eunoia to v1.9.0
+
 ## [1.8.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.7.0...eunoia-npm-v1.8.0) (2026-07-15)
 
 ### Features

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jolars/eunoia",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Area-proportional Euler and Venn diagrams",
   "private": true,
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
## [eunoia: 1.9.0](https://github.com/jolars/eunoia/compare/v1.8.0...v1.9.0) (2026-08-21)

### Features
- **capi:** expose label obstacle boxes ([`2d12be2`](https://github.com/jolars/eunoia/commit/2d12be2b4dd63386bf2463343d1cbf0663af25c9))
- **plotting:** add exterior set-label placement ([`1f09e0d`](https://github.com/jolars/eunoia/commit/1f09e0d2588e1eb8ceec7666209f67e9aec1dfd2))
- **plotting:** relax the random glyph scatter ([`5c4c3b3`](https://github.com/jolars/eunoia/commit/5c4c3b323ada75d356b85af085b19b362198ad37))
- **web:** expose member labels as glyphs ([`5e47729`](https://github.com/jolars/eunoia/commit/5e477298a397a9d21a45b3529ac8512086fbf0e2))
- pack member text labels as glyph boxes ([`8950e8b`](https://github.com/jolars/eunoia/commit/8950e8b37098d91847c36b5caee9a917f119d408))
- **plotting:** keep glyphs clear of label boxes ([`eb8c850`](https://github.com/jolars/eunoia/commit/eb8c8502c682bbf609637dd3aba981e1dc6b4e29))
- add eulerGlyphs-style glyph placement ([`3665c2e`](https://github.com/jolars/eunoia/commit/3665c2ecbd536ec461db418050579708f69a8033))

### Bug Fixes
- **plotting:** keep glyphs clear of region edges ([`badf54a`](https://github.com/jolars/eunoia/commit/badf54a1d517a012ad7159cded863ddf2a29b9de))
- **fitter:** skip cluster rotation for axis-aligned shapes ([`9dc14dd`](https://github.com/jolars/eunoia/commit/9dc14ddc4501adba849a4af8e3bd8bd9264d5bd5)), refs [#133](https://github.com/jolars/eunoia/issues/133)
- **fitter:** bound rectangle size params in optimizer box ([`9e4c901`](https://github.com/jolars/eunoia/commit/9e4c9015b3e541dd54117071761179a45bf75360)), refs [#133](https://github.com/jolars/eunoia/issues/133)

## [ts: 1.9.0](https://github.com/jolars/eunoia/compare/eunoia-npm-v1.8.0...eunoia-npm-v1.9.0) (2026-08-21)

### Features
- **plotting:** add exterior set-label placement ([`1f09e0d`](https://github.com/jolars/eunoia/commit/1f09e0d2588e1eb8ceec7666209f67e9aec1dfd2))
- **web:** add quantities and glyphs to app ([`b1d8aad`](https://github.com/jolars/eunoia/commit/b1d8aad9d9027e1d9505ee4e0c802f8610ac16bb))
- **ts:** render member-label glyph boxes in toSvg ([`0a29be2`](https://github.com/jolars/eunoia/commit/0a29be20e856c409ec3c00a23a5f77f6f3b53ff4))
- **ts:** add placeGlyphBoxesForRegions ([`64c92d0`](https://github.com/jolars/eunoia/commit/64c92d027b16502cae1bbfe5ddc30fee222f4ddf))
- **ts:** color glyphs from their region and give them edges ([`f41b85d`](https://github.com/jolars/eunoia/commit/f41b85dc272cbc698bf3697bcb940107d0b7e1f2))
- **plotting:** keep glyphs clear of label boxes ([`eb8c850`](https://github.com/jolars/eunoia/commit/eb8c8502c682bbf609637dd3aba981e1dc6b4e29))
- add eulerGlyphs-style glyph placement ([`3665c2e`](https://github.com/jolars/eunoia/commit/3665c2ecbd536ec461db418050579708f69a8033))

### Bug Fixes
- **plotting:** keep glyphs clear of region edges ([`badf54a`](https://github.com/jolars/eunoia/commit/badf54a1d517a012ad7159cded863ddf2a29b9de))

### Dependencies
- updated eunoia to v1.9.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).